### PR TITLE
Removed lowercasing of Cfn Properties for Boto3 compatibility

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/Boto3/lambda/resource.py
+++ b/aws/services/CloudFormation/MacrosExamples/Boto3/lambda/resource.py
@@ -55,7 +55,7 @@ def execute(action, properties):
         return "FAILED", "boto3 error: {}".format(e)
 
     properties = {
-        key[0].lower() + key[1:]: value
+        key[0] + key[1:]: value
         for key, value in properties.items()
     }
 


### PR DESCRIPTION
*Description of changes:*

Currently all CloudFormation properties supplied are automatically lowercased for cosmetic reasons. This causes boto3 calls to fail, since boto3 requires the request parameters to be case sensitive. This fix removes the lowercasing of properties.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
