### PR TITLE
Update CloudFront.yaml

### DIFF
--- a/aws/solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
+++ b/aws/solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
@@ -679,7 +679,7 @@ Resources:
               LambdaFunctionARN: !Ref 'LambdaEdgeVersion'
         PriceClass: !Ref 'PriceClass'
         ViewerCertificate:
-          ACMCertificateIdentifier: !Sub 'arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/${ACMCertificateIdentifier}'
+          AcmCertificateArn: !Sub 'arn:aws:acm:${AWS::Region}:${AWS::AccountId}:certificate/${ACMCertificateIdentifier}'
           SslSupportMethod:  !Ref 'SslSupportMethod'
           MinimumProtocolVersion: !Ref 'MinimumProtocolVersion'
         IPV6Enabled: !Ref 'IPV6Enabled'


### PR DESCRIPTION
If you're using AWS CloudFormation, be aware that you must use AcmCertificateArn instead of ACMCertificateArn (note the difference in capitalization) because of how the CloudFormation model is specified. 

As seen here: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ViewerCertificate.html#cloudfront-Type-ViewerCertificate-ACMCertificateArn

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
