### PR TITLE
Paramater for compression had wrong description

### DIFF
--- a/aws/solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
+++ b/aws/solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
@@ -152,7 +152,7 @@ Parameters:
       - https-only
 
   Compress:
-    Description:    CloudFront Origin Protocol Policy to apply to your origin.
+    Description:    CloudFront should support gzip compression requests: Accept-Encoding: gzip.
     Type:           String
     Default:        "false"
     AllowedValues:


### PR DESCRIPTION
Referred to the AWS documentation and provided a description.
China AWS documentation for some reason, still accurate:
https://docs.amazonaws.cn/en_us/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html
https://docs.amazonaws.cn/en_us/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-defaultcachebehavior.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
