### PR TITLE
Fix reference to test.yml in Explode macro example

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/Explode/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/README.md
@@ -31,7 +31,7 @@ aws cloudformation deploy \
 ```shell
 aws cloudformation deploy \
     --stack-name Explode-test \
-    --template-file test.yaml \
+    --template-file test.yml \
     --capabilities CAPABILITY_IAM
 ```
 


### PR DESCRIPTION
The provided file is test.yml, but the instructions reference test.yaml.

*Issue #, if available:* N/A

*Description of changes:* Made the README example consistent with the provided file names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
