### PR TITLE
easy_install is deprecated, using it wont work anymore

### DIFF
--- a/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/ubuntu.template
@@ -134,9 +134,9 @@ Resources:
            dpkg -i /tmp/amazon-cloudwatch-agent.deb
            apt-get update -y
            apt-get  install -y python-pip
-           easy_install --script-dir /opt/aws/bin  https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+           pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+           /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+           /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
     CreationPolicy:
       ResourceSignal:
         Count: 1


### PR DESCRIPTION
*Description of changes:*
Easy_Install is depracated, this makes this sample template not work anymore, resulting in the creation of the EC2 to fail with timeout to receive the signal from EC2, because the bootstrap scripts are not correctly installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
