### PR TITLE
refer to newly released built-in StackSet resource

### DIFF
--- a/aws/solutions/StackSetsResource/README.md
+++ b/aws/solutions/StackSetsResource/README.md
@@ -1,4 +1,13 @@
 # StackSetsResource
+
+----
+
+## Built-in Stack Set Resource 
+
+Before you use the custom resource in this repository, see the AWS CloudFormation [AWS::CloudFormation::StackSet](https://docs.aws.amazon.com/en_us/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html) resource.  This built-in resource was made available in September, 2020.
+
+----
+
 AWS CloudFormation Lambda-backed Custom Resource for launching StackSets.
 
 The lambda function is written in Python and based on the  [crhelper.py](https://github.com/awslabs/aws-cloudformation-templates/tree/master/community/custom_resources/python_custom_resource_helper) Custom Resource framework.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Since AWS CloudFormation released a built-in resource for StackSets, I updated the README file for the older StackSet resource to highlight that people should review the built-in resource before attempting to use the custom resource.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
