### PR TITLE
Bug fix and improve logging to CloudWatch (Explode Macro)

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
@@ -5,6 +5,7 @@ CloudFormation template transform macro: Explode
 import re
 import sys
 import logging
+import json
 
 EXPLODE_RE = re.compile(r'(?i)!Explode (?P<explode_key>\w+)')
 logger = logging.getLogger(__name__)
@@ -44,10 +45,10 @@ def replace_explode_in_string(value, map_data):
         try:
             replace_value = map_data[explode_key]
         except KeyError:
-            print("Missing item {} in mapping while processing {}: {}".format(
+            raise Exception ("Missing item {} in mapping while processing: {}\nMap Data:\n{}".format(
                 explode_key,
-                key,
-                value))
+                value,
+                json.dumps(map_data, indent=4)))
         if isinstance(replace_value, int):
             value = replace_value
             # No further explosion is possible on an int
@@ -125,7 +126,6 @@ if __name__ == "__main__":
     Relatedly, always outputs JSON.
     """
     if len(sys.argv) == 2:
-        import json
         filename = sys.argv[1]
         if filename.endswith(".yml") or filename.endswith(".yaml"):
             try:

--- a/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
@@ -4,10 +4,10 @@ CloudFormation template transform macro: Explode
 
 import re
 import sys
-
+import logging
 
 EXPLODE_RE = re.compile(r'(?i)!Explode (?P<explode_key>\w+)')
-
+logger = logging.getLogger(__name__)
 
 def walk_resource(resource, map_data):
     """Recursively process a resource."""
@@ -29,7 +29,7 @@ def walk_resource(resource, map_data):
                 new_resource.append(replace_explode_in_string(value, map_data))
             else:
                 new_resource.append(value)
-           
+
     else:
         # if the resource is of type string
         new_resource = replace_explode_in_string(resource, map_data)
@@ -75,8 +75,7 @@ def handle_section_transform(section, mappings):
         except KeyError:
             # This resource refers to a mapping entry which doesn't exist, so
             # fail
-            print('Unable to find mapping for exploding object {}'.format(resource_name))
-            raise
+            raise Exception('Unable to find mapping for exploding object {}'.format(resource_name))
         resource_instances = explode_map_data.keys()
         for resource_instance in resource_instances:
             new_resource = walk_resource(resource, explode_map_data[resource_instance])
@@ -107,7 +106,8 @@ def handler(event, _context):
 
     try:
         fragment = handle_transform(fragment)
-    except:
+    except Exception as e:
+        logger.error(e.__str__())
         status = "failure"
 
     return {

--- a/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/lambda/explode.py
@@ -142,4 +142,4 @@ if __name__ == "__main__":
             print("Test file needs to end .yaml, .yml or .json")
             sys.exit(1)
         new_fragment = handle_transform(loaded_fragment)
-        print(json.dumps(new_fragment))
+        print(json.dumps(new_fragment,indent=4))


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Love this macro, although found it frustrating that there was no logging of errors anywhere. Examination of the code revealed that there was no real logging going on, and while I was looking at this found a bug in the exception handler within `replace_explode_in_string()`

Would be nice for CloudFormation to actually return a decent error message when there is an issue. Presume this can be done in the dict returned by the lambda handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
