### PR TITLE
Updated example EC2 launch type template to include t3 instance types.

### DIFF
--- a/aws/services/ECS/EC2LaunchType/clusters/public-vpc.yml
+++ b/aws/services/ECS/EC2LaunchType/clusters/public-vpc.yml
@@ -20,7 +20,8 @@ Parameters:
     Description: EC2 instance type
     Type: String
     Default: c4.xlarge
-    AllowedValues: [t2.micro, t2.small, t2.medium, t2.large, m3.medium, m3.large,
+    AllowedValues: [t3.micro, t3.small, t3.medium, t3.large, t2.micro, t2.small,
+      t2.medium, t2.large, m3.medium, m3.large,
       m3.xlarge, m3.2xlarge, m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m4.10xlarge,
       c4.large, c4.xlarge, c4.2xlarge, c4.4xlarge, c4.8xlarge, c3.large, c3.xlarge,
       c3.2xlarge, c3.4xlarge, c3.8xlarge, r3.large, r3.xlarge, r3.2xlarge, r3.4xlarge,


### PR DESCRIPTION
*Issue #, if available:*
No issue for this.  I just noticed the instance types could use an update so I added them.

*Description of changes:*
Added `t3` instance types to the EC2 ECS launch parameters.  The example looks like it predates these instance types and I was going to use them so I decided to contribute it back.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
