### PR TITLE
Update transform configuration from list to object

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/StringFunctions/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/StringFunctions/README.md
@@ -20,11 +20,11 @@ Resources:
       Tags:
         - Key: Upper
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: Upper
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: Upper
 ```
 
 ## Available Operations

--- a/aws/services/CloudFormation/MacrosExamples/StringFunctions/string_example.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/StringFunctions/string_example.yaml
@@ -11,63 +11,63 @@ Resources:
       Tags:
         - Key: Upper
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: Upper
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: Upper
         - Key: Lower
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: Lower
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: Lower
         - Key: Capitalize
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: Capitalize
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: Capitalize
         - Key: Title
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: Title
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: Title
         - Key: Replace
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: Replace
-                 Old: " "
-                 New: "_"
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: Replace
+                Old: " "
+                New: "_"
         - Key: Strip
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: Strip
-                 Chars: Tgif
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: Strip
+                Chars: Tgif
         - Key: ShortenLeft
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: MaxLength
-                 Length: 4
-                 StripFrom: Left
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: MaxLength
+                Length: 4
+                StripFrom: Left
         - Key: ShortenRight
           Value:
-            'Fn::Transform':
-             - Name: 'String'
-               Parameters:
-                 InputString: !Ref InputString
-                 Operation: MaxLength
-                 Length: 4
+            Fn::Transform:
+              Name: 'String'
+              Parameters:
+                InputString: !Ref InputString
+                Operation: MaxLength
+                Length: 4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The transform example shown for Strings is configured to use list in Fn::Transform, however, an object is expected instead of a list, as given in the documentation - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-transform.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
