### PR TITLE
S3Objects: Return error message if transform fails

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/S3Objects/lambda/macro.py
+++ b/aws/services/CloudFormation/MacrosExamples/S3Objects/lambda/macro.py
@@ -78,6 +78,7 @@ def handler(event, context):
         return {
             "requestId": event["requestId"],
             "status": "failure",
+            "errorMessage": str(e),
             "fragment": event["fragment"],
         }
 


### PR DESCRIPTION
Changes the `S3Objects` macro to return a more descriptive error message when the transform step fails.

## Before:
> Failed to create the changeset: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Transform …::S3Objects failed without an error message.

## After:
> Failed to create the changeset: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Transform …::S3Objects failed with: You must specify exactly one of: Body, Base64Body, Source
