### PR TITLE
Fix DatetimeNow macro example

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
+++ b/aws/services/CloudFormation/MacrosExamples/DatetimeNow/README.md
@@ -20,9 +20,9 @@ Resources:
         - Key: DatetimeNow
           Value:
             'Fn::Transform':
-             - Name: 'String'
+             - Name: 'DatetimeNow'
                Parameters:
-                 param: '%Y-%m-%d %H:%M:%S'
+                 format: '%Y-%m-%d %H:%M:%S'
 ```
 
 ## Author


### PR DESCRIPTION
as it currently refers to a non-existent transform and parameter.

*Description of changes:*
1. change the transform name from `'String'` to `'DatetimeNow'`
When I run the example as is, I get the error `No transform named <account ID>::String found.`

1. change the parameter name from `'param'` to `'format'`
When I run the example as is, I get the error `Transform <account ID>::DatetimeNow failed with: 'format'`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
