### PR TITLE
Pyplate support for calling AWS APIs and Python version to 3.10.

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/PyPlate/python.yaml
+++ b/aws/services/CloudFormation/MacrosExamples/PyPlate/python.yaml
@@ -1,5 +1,30 @@
 AWSTemplateFormatVersion: 2010-09-09
+
+Description: Macro allowing you to run arbitrary python code in your CloudFormation templates
+
+Parameters:
+  AdditionalExecutionPolicy:
+    Type: String
+    Description: >-
+      An optional IAM Policy ARN to add to the Lambda's execution role
+      so that the template's Python code can call AWS services.
+
+  LambdaTimeout:
+    Type: Number
+    Description: >-
+      Optional setting of the Lambda's execution timeout (in seconds).
+      The default of 3 seconds won't be enough if you call AWS services;
+      then at least 10 seconds is recommended, more depending on complexity.
+    MinValue: 3
+    Default: 3
+
+Conditions:
+  AdditionalPolicyProvided:
+    Fn::Not:
+    - Fn::Equals: [Ref: AdditionalExecutionPolicy, '']
+
 Resources:
+
   TransformExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -19,9 +44,17 @@ Resources:
               - Effect: Allow
                 Action: ['logs:*']
                 Resource: 'arn:aws:logs:*:*:*'
+      ManagedPolicyArns:
+      - !If
+        - AdditionalPolicyProvided
+        - !Ref AdditionalExecutionPolicy
+        # Else
+        - !Ref AWS::NoValue
+
   TransformFunction:
     Type: AWS::Lambda::Function
     Properties:
+      Description: Support for the PyPlate CloudFormation macro
       Code:
         ZipFile: |
           import traceback
@@ -67,14 +100,17 @@ Resources:
               return macro_response
 
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.10
       Role: !GetAtt TransformExecutionRole.Arn
+      Timeout: !Ref LambdaTimeout
+
   TransformFunctionPermissions:
     Type: AWS::Lambda::Permission
     Properties:
       Action: 'lambda:InvokeFunction'
       FunctionName: !GetAtt TransformFunction.Arn
       Principal: 'cloudformation.amazonaws.com'
+
   Transform:
     Type: AWS::CloudFormation::Macro
     Properties:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added the ability for PyPlate to call AWS services via boto3.  When the PyPlate template is deployed an optional IAM Policy ARN can be provided which gets added to the Lambda execution role, providing AWS API permissions.  An optional override of the default Lambda 3-second timeout can also be provided; more time is needed for boto3 functionality, close on 5 seconds at least, so 10 seconds is recommended as a minimum.

Increased the Python version from 3.6 to 3.10.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
