### PR TITLE
Update Explode CFN Macro to Python 3.11

### DIFF
--- a/aws/services/CloudFormation/MacrosExamples/Explode/macro.yml
+++ b/aws/services/CloudFormation/MacrosExamples/Explode/macro.yml
@@ -4,7 +4,7 @@ Resources:
   MacroFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.7
+      Runtime: python3.11
       CodeUri: lambda
       Handler: explode.handler
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The CloudFormation explode macro sample currently uses Python3.7 in the `macro.yml` template, which is deprecated. This change updates the Lambda to use 3.11.

*Testing:*
Testing the function locally, the macro lambda code appears to work at 3.11.
```text
bash-3.2$ .venv/bin/python --version
Python 3.11.4

bash-3.2$ .venv/bin/python -m pip list
Package    Version
---------- -------
pip        23.0.1
PyYAML     6.0.1
setuptools 67.6.1

[notice] A new release of pip is available: 23.0.1 -> 23.3.1
[notice] To update, run: /Users/elliotsegler/workspace/aws-cloudformation-templates/aws/services/CloudFormation/MacrosExamples/Explode/.venv/bin/python -m pip install --upgrade pip

bash-3.2$ .venv/bin/python lambda/explode.py test.yml | .venv/bin/python -m json.tool
{
    "AWSTemplateFormatVersion": "2010-09-09",
    "Transform": "Explode",
    "Mappings": {
        "BucketMap": {
            "Monthly": {
                "ResourceName": "MyThirtyDayBucket",
                "Retention": 30
            },
            "Yearly": {
                "Retention": 365
            }
        }
    },
    "Resources": {
        "MyThirtyDayBucket": {
            "Type": "AWS::S3::Bucket",
            "Properties": {
                "LifecycleConfiguration": {
                    "Rules": [
                        {
                            "ExpirationInDays": 30,
                            "Status": "Enabled"
                        }
                    ]
                }
            }
        },
        "BucketYearly": {
            "Type": "AWS::S3::Bucket",
            "Properties": {
                "LifecycleConfiguration": {
                    "Rules": [
                        {
                            "ExpirationInDays": 365,
                            "Status": "Enabled"
                        }
                    ]
                }
            }
        },
        "NonExplodingBucket": {
            "Type": "AWS::S3::Bucket"
        }
    }
}
```

We've deployed the updated lambdas to our envionment and everything looks ok.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
