### PR TITLE
Retrieved Amazon Linux AMI from SSM Parameter Store automatically.

### DIFF
--- a/aws/solutions/AmazonCloudWatchAgent/inline/amazon_linux.template
+++ b/aws/solutions/AmazonCloudWatchAgent/inline/amazon_linux.template
@@ -13,8 +13,8 @@ Parameters:
     ConstraintDescription: must be a valid EC2 instance type.
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type : String
-    Default: ami-7707a10f
+    Type : AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: arn:aws:ssm:us-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
   IAMRole:
     Description: EC2 attached IAM role
     Type: String

--- a/aws/solutions/AmazonCloudWatchAgent/ssm/amazon_linux.template
+++ b/aws/solutions/AmazonCloudWatchAgent/ssm/amazon_linux.template
@@ -17,8 +17,8 @@ Parameters:
     ConstraintDescription: must be a valid EC2 instance type.
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type : String
-    Default: ami-7707a10f
+    Type : AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: arn:aws:ssm:us-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
   IAMRole:
     Description: EC2 attached IAM role
     Type: String


### PR DESCRIPTION
I have modified the code in the AmazonCloudWatchAgent folder inside the solutions folder. For all the Amazon Linux templates, I have modified the AMI parameter to retrieve the AMI ID from the SSM Parameter Store.
```diff
-   InstanceAMI:
-       Description: Managed AMI ID for EC2 Instance
-       Type : String
-       Default: ami-7707a10f
+   InstanceAMI:
+      Description: Managed AMI ID for EC2 Instance
+      Type : AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+       Default: arn:aws:ssm:us-east-1::parameter/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
```

Unfortunately, I could not find a way to do this for the other images.