### PR TITLE
Update Ubuntu22.04_cfn-hup.yaml

### DIFF
--- a/aws/solutions/OperatingSystems/Ubuntu22.04_cfn-hup.yaml
+++ b/aws/solutions/OperatingSystems/Ubuntu22.04_cfn-hup.yaml
@@ -245,11 +245,11 @@ Resources:
                   - |
                     triggers=post.update
                   - >
-                    path=Resources.WebServerInstance.Metadata.AWS::CloudFormation::Init
+                    path=Resources.EC2Instance.Metadata.AWS::CloudFormation::Init
                   - 'action=/opt/aws/bin/cfn-init -v '
                   - '         --stack '
                   - !Ref 'AWS::StackName'
-                  - '         --resource WebServerInstance '
+                  - '         --resource EC2Instance '
                   - '         --configsets InstallAndRun '
                   - '         --region '
                   - !Ref 'AWS::Region'


### PR DESCRIPTION
fixed incorrect resource name preventing cfn scripts from properly running

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
