### PR TITLE
Pass tcp port as parameter, fix W3005 Obsolete DependsOn per cfn-lint

### DIFF
--- a/AppRunner/AppRunnerServiceFromECR.json
+++ b/AppRunner/AppRunnerServiceFromECR.json
@@ -13,7 +13,7 @@
         "TCPPORT": {
             "Description": "Port on which the container is listening.",
             "Type": "Number",
-            "Default": "80"
+            "Default": 80
         }
     },
     "Resources": {

--- a/AppRunner/AppRunnerServiceFromECR.json
+++ b/AppRunner/AppRunnerServiceFromECR.json
@@ -8,7 +8,12 @@
         "ECRURL": {
             "Description": "URL of the ECR Repository.",
             "Type": "String",
-            "Default": "123456789012.dkr.ecr.us-east-1.amazonaws.com/ecr-name:latest"
+            "Default": "123456789012.dkr.ecr.us-east-2.amazonaws.com/cfntest:apache"
+        },
+        "TCPPORT": {
+            "Description": "Port on which the container is listening.",
+            "Type": "Number",
+            "Default": "80"
         }
     },
     "Resources": {
@@ -57,7 +62,6 @@
         },
         "AppRunner": {
             "Type": "AWS::AppRunner::Service",
-            "DependsOn": "AppRunnerRole",
             "Properties": {
                 "ServiceName": {
                     "Fn::Join": [
@@ -86,7 +90,9 @@
                             "Ref": "ECRURL"
                         },
                         "ImageConfiguration": {
-                            "Port": 8080
+                            "Port": {
+                                "Ref": "TCPPORT"
+                            }
                         }
                     }
                 }

--- a/AppRunner/AppRunnerServiceFromECR.yaml
+++ b/AppRunner/AppRunnerServiceFromECR.yaml
@@ -9,7 +9,11 @@ Parameters:
   ECRURL:
     Description: URL of the ECR Repository.
     Type: String
-    Default: 123456789012.dkr.ecr.us-east-1.amazonaws.com/ecr-name:latest
+    Default: 123456789012.dkr.ecr.us-east-2.amazonaws.com/cfntest:apache
+  TCPPORT:
+    Description: Port on which the container is listening.
+    Type: Number
+    Default: 80
 
 Resources:
   AppRunnerRole:
@@ -41,7 +45,6 @@ Resources:
 
   AppRunner:
     Type: AWS::AppRunner::Service
-    DependsOn: AppRunnerRole
     Properties:
       ServiceName: !Join
         - ""
@@ -55,8 +58,7 @@ Resources:
           ImageRepositoryType: ECR
           ImageIdentifier: !Ref ECRURL
           ImageConfiguration:
-            Port: 8080
-
+            Port: !Ref TCPPORT
             # Default Configurations
             # InstanceConfiguration:
             #   Cpu: 1024

--- a/AppRunner/AppRunnerServiceFromECR.yaml
+++ b/AppRunner/AppRunnerServiceFromECR.yaml
@@ -10,6 +10,7 @@ Parameters:
     Description: URL of the ECR Repository.
     Type: String
     Default: 123456789012.dkr.ecr.us-east-2.amazonaws.com/cfntest:apache
+
   TCPPORT:
     Description: Port on which the container is listening.
     Type: Number
@@ -59,6 +60,7 @@ Resources:
           ImageIdentifier: !Ref ECRURL
           ImageConfiguration:
             Port: !Ref TCPPORT
+
             # Default Configurations
             # InstanceConfiguration:
             #   Cpu: 1024


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Ran cfn-lint and fixed the warning. DependsOn attribute on the  AppRunner resource is unnecessary, as the dependency is already being enforced through the use of Fn::GetAtt. 

2. Also the TCP port was hard-coded so made changes to pass in parameter

3. `bash ../scripts/test-all.sh                             
Formatting YAML files...
./AppRunnerServiceFromECR.yaml
Generating JSON files based on YAML...
Creating ./AppRunnerServiceFromECR.json based on ./AppRunnerServiceFromECR.yaml
Linting with config file ../scripts/../.cfnlintrc
Linting ./AppRunnerServiceFromECR.yaml
Guarding...
Running cfn-guard on ./AppRunnerServiceFromECR.yaml using ../scripts/rules.guard
Success
Success
Success
`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
