### PR TITLE
Cleanup issues with sample RDS templates creating and deleting cleanly

### DIFF
--- a/RDS/RDS_MySQL_With_Read_Replica.yaml
+++ b/RDS/RDS_MySQL_With_Read_Replica.yaml
@@ -88,10 +88,19 @@ Resources:
           SourceSecurityGroupName: !Ref EC2SecurityGroup
     Condition: IsEC2VPC
 
+  DBCredential:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      GenerateSecretString:
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+        RequireEachIncludedType: true
+
   MainDB:
     DeletionPolicy: Snapshot
     UpdateReplacePolicy: Snapshot
     Type: AWS::RDS::DBInstance
+    DependsOn: DBCredential
     Properties:
       DBName: !Ref DBName
       AllocatedStorage: !Ref DBAllocatedStorage
@@ -99,7 +108,7 @@ Resources:
       DBInstanceClass: !Ref DBInstanceClass
       Engine: MySQL
       MasterUsername: !Ref DBUser
-      MasterUserPassword: '{{resolve:secretsmanager:my-db-password}}'
+      MasterUserPassword: !Sub '{{resolve:secretsmanager:${DBCredential}}}'
       MultiAZ: !Ref MultiAZ
       PubliclyAccessible: false
       StorageEncrypted: true
@@ -130,6 +139,10 @@ Resources:
     Condition: EnableReadReplica
 
 Outputs:
+  DBCredentialSecretNameArn:
+    Description: Name of the secret containing the database credential
+    Value: !Ref DBCredential
+
   EC2Platform:
     Description: Platform in which this stack is deployed
     Value: !If

--- a/RDS/RDS_PIOPS.yaml
+++ b/RDS/RDS_PIOPS.yaml
@@ -16,8 +16,17 @@ Parameters:
     ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
 
 Resources:
+  DBCredential:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      GenerateSecretString:
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+        RequireEachIncludedType: true
+
   myDB:
     Type: AWS::RDS::DBInstance
+    DependsOn: DBCredential
     Properties:
       AllocatedStorage: "100"
       DBInstanceClass: db.t3.small
@@ -25,6 +34,6 @@ Resources:
       Engine: MySQL
       Iops: "1000"
       MasterUsername: !Ref DBUser
-      MasterUserPassword: '{{resolve:secretsmanager:my-db-password}}'
+      MasterUserPassword: !Sub '{{resolve:secretsmanager:${DBCredential}}}'
       PubliclyAccessible: false
       StorageEncrypted: true

--- a/RDS/RDS_with_DBParameterGroup.yaml
+++ b/RDS/RDS_with_DBParameterGroup.yaml
@@ -55,12 +55,11 @@ Resources:
   MyRDSParamGroup:
     Type: AWS::RDS::DBParameterGroup
     Properties:
-      Family: MySQL5.6
+      Family: MySQL8.0
       Description: CloudFormation Sample Database Parameter Group
       Parameters:
         autocommit: "1"
         general_log: "1"
-        old_passwords: "0"
 
 Outputs:
   JDBCConnectionString:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added SecretsManager to RDS_MySQL_With_Read_Replica and RDS_PIOPS templates.
Updated MySQL Family version in RDS_with_DBParameterGroup template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
