### PR TITLE
Fix: Replace SecurityGroups with SecurityGroupIds in EC2 resource

### DIFF
--- a/EC2/EC2InstanceWithSecurityGroupSample.json
+++ b/EC2/EC2InstanceWithSecurityGroupSample.json
@@ -91,9 +91,12 @@
                         }
                     ]
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
+                        "Fn::GetAtt": [
+                            "InstanceSecurityGroup",
+                            "GroupId"
+                        ]
                     }
                 ],
                 "KeyName": {


### PR DESCRIPTION
## Overview
This PR fixes an issue where specifying the security group name (`groupName`) in the `AWS::EC2::Instance` resource along with the subnet parameter causes an error. The security group should be referenced by its ID rather than by its name.

## Changes
 - Updated the `SecurityGroups` parameter to `SecurityGroupIds` and used `Fn::GetAtt` to retrieve the security group ID.
 - This change ensures proper association between the subnet and security group, preventing errors during EC2 instance creation.

## Background
The AWS EC2 API does not allow the use of `groupName` (security group name) in combination with `subnet`. Instead, security groups must be referenced by their ID. This change addresses that limitation by updating the template to use the security group ID.

## Testing
The updated template was successfully tested by creating a stack without encountering errors.