### PR TITLE
Fix: Replace SecurityGroups with SecurityGroupIds in YAML template

### DIFF
--- a/EC2/EC2InstanceWithSecurityGroupSample.yaml
+++ b/EC2/EC2InstanceWithSecurityGroupSample.yaml
@@ -83,8 +83,8 @@ Resources:
       SubnetId: !Select
         - 0
         - !Ref Subnets
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       KeyName: !Ref KeyName
       ImageId: !Ref LatestAmiId
 


### PR DESCRIPTION
## Overview
This PR addresses the same issue as identified in [PR #450], where using `groupName` (security group name) alongside the `subnet` parameter in the EC2 instance configuration results in an error. The CloudFormation YAML template has been updated to reference security groups by ID instead of name.

## Changes
 - Replaced `SecurityGroups` with `SecurityGroupIds` and used `!GetAtt` to fetch the security group ID.
 - This update resolves the conflict between subnet and security group name when creating EC2 instances.

## Background
Similar to the changes made in PR #hoge, the AWS EC2 API does not allow the use of `groupName` (security group name) with a `subnet` parameter. Instead, security groups must be referenced by their ID, which is the focus of this fix.

## Testing
The updated CloudFormation YAML template was successfully validated, and EC2 instance creation proceeded without errors.