### PR TITLE
Fix error value (us-east-1us-east-1a) for parameter availabilityZone is invalid

### DIFF
--- a/VPC/VPC_With_Managed_NAT_And_Private_Subnet.json
+++ b/VPC/VPC_With_Managed_NAT_And_Private_Subnet.json
@@ -67,17 +67,10 @@
                     "Ref": "VPC"
                 },
                 "AvailabilityZone": {
-                    "Fn::Sub": [
-                        "${AWS::Region}${AZ}",
+                    "Fn::Select": [
+                        0,
                         {
-                            "AZ": {
-                                "Fn::Select": [
-                                    0,
-                                    {
-                                        "Fn::GetAZs": null
-                                    }
-                                ]
-                            }
+                            "Fn::GetAZs": null
                         }
                     ]
                 },
@@ -132,17 +125,10 @@
                     "Ref": "VPC"
                 },
                 "AvailabilityZone": {
-                    "Fn::Sub": [
-                        "${AWS::Region}${AZ}",
+                    "Fn::Select": [
+                        1,
                         {
-                            "AZ": {
-                                "Fn::Select": [
-                                    1,
-                                    {
-                                        "Fn::GetAZs": null
-                                    }
-                                ]
-                            }
+                            "Fn::GetAZs": null
                         }
                     ]
                 },
@@ -197,17 +183,10 @@
                     "Ref": "VPC"
                 },
                 "AvailabilityZone": {
-                    "Fn::Sub": [
-                        "${AWS::Region}${AZ}",
+                    "Fn::Select": [
+                        0,
                         {
-                            "AZ": {
-                                "Fn::Select": [
-                                    0,
-                                    {
-                                        "Fn::GetAZs": null
-                                    }
-                                ]
-                            }
+                            "Fn::GetAZs": null
                         }
                     ]
                 },
@@ -261,17 +240,10 @@
                     "Ref": "VPC"
                 },
                 "AvailabilityZone": {
-                    "Fn::Sub": [
-                        "${AWS::Region}${AZ}",
+                    "Fn::Select": [
+                        1,
                         {
-                            "AZ": {
-                                "Fn::Select": [
-                                    1,
-                                    {
-                                        "Fn::GetAZs": null
-                                    }
-                                ]
-                            }
+                            "Fn::GetAZs": null
                         }
                     ]
                 },

--- a/VPC/VPC_With_Managed_NAT_And_Private_Subnet.yaml
+++ b/VPC/VPC_With_Managed_NAT_And_Private_Subnet.yaml
@@ -43,11 +43,9 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Sub
-        - ${AWS::Region}${AZ}
-        - AZ: !Select
-            - 0
-            - !GetAZs
+      AvailabilityZone: !Select
+        - 0
+        - !GetAZs
       CidrBlock: !FindInMap
         - SubnetConfig
         - Public0
@@ -71,11 +69,9 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Sub
-        - ${AWS::Region}${AZ}
-        - AZ: !Select
-            - 1
-            - !GetAZs
+      AvailabilityZone: !Select
+        - 1
+        - !GetAZs
       CidrBlock: !FindInMap
         - SubnetConfig
         - Public1
@@ -99,11 +95,9 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Sub
-        - ${AWS::Region}${AZ}
-        - AZ: !Select
-            - 0
-            - !GetAZs
+      AvailabilityZone: !Select
+        - 0
+        - !GetAZs
       CidrBlock: !FindInMap
         - SubnetConfig
         - Private0
@@ -126,11 +120,9 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Sub
-        - ${AWS::Region}${AZ}
-        - AZ: !Select
-            - 1
-            - !GetAZs
+      AvailabilityZone: !Select
+        - 1
+        - !GetAZs
       CidrBlock: !FindInMap
         - SubnetConfig
         - Private1


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Remove duplicate aws::region in availabilityZone to avoid error: Value (us-east-1us-east-1a) for parameter availabilityZone is invalid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.