### PR TITLE
Updated templates with the SSM pseudo parameters for AMIs and mappings for other OS

### DIFF
--- a/Solutions/AmazonCloudWatchAgent/inline/amazon_linux.json
+++ b/Solutions/AmazonCloudWatchAgent/inline/amazon_linux.json
@@ -10,13 +10,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-7707a10f"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -125,10 +125,12 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    }   
+                    
                 ],
                 "UserData": {
                     "Fn::Base64": {

--- a/Solutions/AmazonCloudWatchAgent/inline/amazon_linux.yaml
+++ b/Solutions/AmazonCloudWatchAgent/inline/amazon_linux.yaml
@@ -11,13 +11,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-7707a10f
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -135,8 +135,8 @@ Resources:
       KeyName: !Ref KeyName
       ImageId: !Ref InstanceAMI
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash

--- a/Solutions/AmazonCloudWatchAgent/inline/centos.json
+++ b/Solutions/AmazonCloudWatchAgent/inline/centos.json
@@ -10,13 +10,16 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
-        "InstanceAMI": {
-            "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-28e07e50"
+        "CentOSVersion": {
+            "Type": "String",
+            "AllowedValues": [
+                "CentOS9"
+            ],
+            "Default": "CentOS9",
+            "Description": "CentOS version to deploy"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -35,6 +38,40 @@
         },
         "SubnetId": {
             "Type": "AWS::EC2::Subnet::Id"
+        }
+    },
+    "Mappings": {
+        "RegionMap": {
+            "us-east-1": {
+                "CentOS9": "ami-0705f7887207411ca"
+            },
+            "us-east-2": {
+                "CentOS9": "ami-0fe2c46c1dc3889fa"
+            },
+            "us-west-1": {
+                "CentOS9": "ami-0f4f63d1732fd4ef5"
+            },
+            "us-west-2": {
+                "CentOS9": "ami-00b231246df1d28de"
+            },
+            "eu-west-1": {
+                "CentOS9": "ami-05a7b8270231783b2"
+            },
+            "eu-west-2": {
+                "RHEL9": "ami-0086646e63ce5aaf1"
+            },
+            "ap-northeast-1": {
+                "RHEL9": "ami-0d8ee41b4b6f8343b"
+            },
+            "ap-northeast-2": {
+                "RHEL9": "ami-031e0786d2134adf6"
+            },
+            "ap-southeast-1": {
+                "RHEL9": "ami-0a9082a6b182a840b"
+            },
+            "ap-southeast-2": {
+                "RHEL9": "ami-05ffc8a6cb624035b"
+            }
         }
     },
     "Resources": {
@@ -120,19 +157,28 @@
                     "Ref": "KeyName"
                 },
                 "ImageId": {
-                    "Ref": "InstanceAMI"
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        {
+                            "Ref": "CentOSVersion"
+                        }
+                    ]
                 },
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
-                        "Fn::Sub": "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm\nyum update -y\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
+                        "Fn::Sub": "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm\nyum update -y\nyum install python3 -y\ncurl -O https://bootstrap.pypa.io/get-pip.py\n# Install pip using python3\npython3 get-pip.py\nexport PATH=$PATH:/usr/local/bin\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
                     }
                 }
             }

--- a/Solutions/AmazonCloudWatchAgent/inline/centos.yaml
+++ b/Solutions/AmazonCloudWatchAgent/inline/centos.yaml
@@ -11,13 +11,15 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
-  InstanceAMI:
-    Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-28e07e50
+  CentOSVersion:
+    Type: String
+    AllowedValues: 
+      - CentOS9
+    Default: CentOS9
+    Description: CentOS version to deploy
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -36,6 +38,29 @@ Parameters:
 
   SubnetId:
     Type: AWS::EC2::Subnet::Id
+
+Mappings:
+  RegionMap:
+    us-east-1:
+      CentOS9: ami-0705f7887207411ca
+    us-east-2:
+      CentOS9: ami-0fe2c46c1dc3889fa
+    us-west-1:
+      CentOS9: ami-0f4f63d1732fd4ef5
+    us-west-2:
+      CentOS9: ami-00b231246df1d28de
+    eu-west-1:
+      CentOS9: ami-05a7b8270231783b2
+    eu-west-2:
+      CentOS9: ami-0086646e63ce5aaf1
+    ap-northeast-1:
+      CentOS9: ami-0d8ee41b4b6f8343b
+    ap-northeast-2:
+      CentOS9: ami-031e0786d2134adf6
+    ap-southeast-1:
+      CentOS9: ami-0a9082a6b182a840b
+    ap-southeast-2:
+      CentOS9: ami-05ffc8a6cb624035b
 
 Resources:
   EC2Instance:
@@ -133,15 +158,23 @@ Resources:
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref IAMRole
       KeyName: !Ref KeyName
-      ImageId: !Ref InstanceAMI
+      ImageId: !FindInMap 
+        - RegionMap
+        - !Ref 'AWS::Region'
+        - !Ref CentOSVersion
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash
           rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm
           yum update -y
+          yum install python3 -y
+          curl -O https://bootstrap.pypa.io/get-pip.py
+          # Install pip using python3
+          python3 get-pip.py
+          export PATH=$PATH:/usr/local/bin
           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/Solutions/AmazonCloudWatchAgent/inline/debian.json
+++ b/Solutions/AmazonCloudWatchAgent/inline/debian.json
@@ -10,13 +10,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-6e1a0117"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/debian/release/10/latest/amd64"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -125,14 +125,15 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
-                        "Fn::Sub": "#!/bin/bash\nwget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb\ndpkg -i /tmp/amazon-cloudwatch-agent.deb\napt-get update -y\napt-get install -y python3 pipx && pipx ensurepath\npipx install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
+                        "Fn::Sub": "#!/bin/bash\nwget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb\nsudo dpkg -i /tmp/amazon-cloudwatch-agent.deb\nwget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz\nsudo apt-get update -y\nsudo apt-get install -y python3-pip python3-venv\n\n# Create and activate a virtual environment\npython3 -m venv /opt/aws/virtualenv\nsource /opt/aws/virtualenv/bin/activate\n\n# Install the bootstrap package\npip install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz\n\n# Create necessary symlinks\nsudo mkdir -p /opt/aws/bin\nsudo ln -s /opt/aws/virtualenv/bin/cfn-* /opt/aws/bin/\n\n# Run cfn-init\n/opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\n/opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
                     }
                 }
             }

--- a/Solutions/AmazonCloudWatchAgent/inline/debian.yaml
+++ b/Solutions/AmazonCloudWatchAgent/inline/debian.yaml
@@ -11,13 +11,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-6e1a0117
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/debian/release/10/latest/amd64
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -135,18 +135,31 @@ Resources:
       KeyName: !Ref KeyName
       ImageId: !Ref InstanceAMI
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash
           wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb
-          dpkg -i /tmp/amazon-cloudwatch-agent.deb
-          apt-get update -y
-          apt-get install -y python3 pipx && pipx ensurepath
-          pipx install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-          cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-          cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+          sudo dpkg -i /tmp/amazon-cloudwatch-agent.deb
+          wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+          sudo apt-get update -y
+          sudo apt-get install -y python3-pip python3-venv
+
+          # Create and activate a virtual environment
+          python3 -m venv /opt/aws/virtualenv
+          source /opt/aws/virtualenv/bin/activate
+
+          # Install the bootstrap package
+          pip install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+
+          # Create necessary symlinks
+          sudo mkdir -p /opt/aws/bin
+          sudo ln -s /opt/aws/virtualenv/bin/cfn-* /opt/aws/bin/
+
+          # Run cfn-init
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
 
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/Solutions/AmazonCloudWatchAgent/inline/redhat.json
+++ b/Solutions/AmazonCloudWatchAgent/inline/redhat.json
@@ -10,13 +10,16 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
-        "InstanceAMI": {
-            "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-28e07e50"
+        "RHELVersion": {
+            "Type": "String",
+            "AllowedValues": [
+                "RHEL9"
+            ],
+            "Default": "RHEL9",
+            "Description": "RHEL version to deploy"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -37,6 +40,42 @@
             "Type": "AWS::EC2::Subnet::Id"
         }
     },
+
+    "Mappings": {
+        "RegionMap": {
+            "us-east-1": {
+                "RHEL9": "ami-0fb13bb53494158e9"
+            },
+            "us-east-2": {
+                "RHEL9": "ami-0aeea2f24f6d3ba32"
+            },
+            "us-west-1": {
+                "RHEL9": "ami-068c2af1200ef7356"
+            },
+            "us-west-2": {
+                "RHEL9": "ami-0367f2b5c3d1ef960"
+            },
+            "eu-west-1": {
+                "RHEL9": "ami-0f0f1c02e5e4d9d9f"
+            },
+            "eu-west-2": {
+                "RHEL9": "ami-02b1e3a99e36afd1a"
+            },
+            "ap-northeast-1": {
+                "RHEL9": "ami-0eade93757ef7bb6c"
+            },
+            "ap-northeast-2": {
+                "RHEL9": "ami-097698b6cd8164ea2"
+            },
+            "ap-southeast-1": {
+                "RHEL9": "ami-0b9521fddc9871128"
+            },
+            "ap-southeast-2": {
+                "RHEL9": "ami-0eea634029e7b983c"
+            }
+        }
+    },
+
     "Resources": {
         "EC2Instance": {
             "CreationPolicy": {
@@ -120,19 +159,28 @@
                     "Ref": "KeyName"
                 },
                 "ImageId": {
-                    "Ref": "InstanceAMI"
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        {
+                            "Ref": "RHELVersion"
+                        }
+                    ]
                 },
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
-                        "Fn::Sub": "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm\nyum update -y\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
+                        "Fn::Sub": "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm\nyum update -y\nyum install python3 -y\ncurl -O https://bootstrap.pypa.io/get-pip.py\n# Install pip using python3\npython3 get-pip.py\nexport PATH=$PATH:/usr/local/bin\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
                     }
                 }
             }

--- a/Solutions/AmazonCloudWatchAgent/inline/redhat.yaml
+++ b/Solutions/AmazonCloudWatchAgent/inline/redhat.yaml
@@ -11,13 +11,15 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
-  InstanceAMI:
-    Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-28e07e50
+  RHELVersion:
+    Type: String
+    AllowedValues: 
+      - RHEL9
+    Default: RHEL9
+    Description: RHEL version to deploy
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -36,6 +38,31 @@ Parameters:
 
   SubnetId:
     Type: AWS::EC2::Subnet::Id
+
+Mappings:
+  RegionMap:
+    us-east-1:
+      RHEL9: ami-0fb13bb53494158e9
+    us-east-2:
+      RHEL9: ami-0aeea2f24f6d3ba32
+    us-west-1:
+      RHEL9: ami-068c2af1200ef7356
+    us-west-2:
+      RHEL9: ami-0367f2b5c3d1ef960
+    eu-west-1:
+      RHEL9: ami-0e28d6c0c65e7f82f
+    eu-west-2:
+      RHEL9: ami-02b1e3a99e36afd1a
+    ap-northeast-1:
+      RHEL9: ami-0eade93757ef7bb6c
+    ap-northeast-2:
+      RHEL9: ami-097698b6cd8164ea2
+    ap-southeast-1:
+      RHEL9: ami-0b9521fddc9871128
+    ap-southeast-2:
+      RHEL9: ami-0eea634029e7b983c
+    
+    
 
 Resources:
   EC2Instance:
@@ -133,15 +160,23 @@ Resources:
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref IAMRole
       KeyName: !Ref KeyName
-      ImageId: !Ref InstanceAMI
+      ImageId: !FindInMap 
+        - RegionMap
+        - !Ref 'AWS::Region'
+        - !Ref RHELVersion
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash
           rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
           yum update -y
+          yum install python3 -y
+          curl -O https://bootstrap.pypa.io/get-pip.py
+          # Install pip using python3
+          python3 get-pip.py
+          export PATH=$PATH:/usr/local/bin
           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/Solutions/AmazonCloudWatchAgent/inline/suse.json
+++ b/Solutions/AmazonCloudWatchAgent/inline/suse.json
@@ -10,13 +10,16 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
-        "InstanceAMI": {
-            "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-28e07e50"
+        "SUSEVersion": {
+            "Type": "String",
+            "AllowedValues": [
+                "SLES15SP5"
+            ],
+            "Default": "SLES15SP5",
+            "Description": "SUSE Linux Enterprise Server version to deploy"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -35,6 +38,40 @@
         },
         "SubnetId": {
             "Type": "AWS::EC2::Subnet::Id"
+        }
+    },
+    "Mappings": {
+        "RegionMap": {
+            "us-east-1": {
+                "SLES15SP5": "ami-0d62a8e6541a2d491"
+            },
+            "us-east-2": {
+                "SLES15SP5": "ami-05d1f1c3db2b2eb0c"
+            },
+            "us-west-1": {
+                "SLES15SP5": "ami-060034d187be82d31"
+            },
+            "us-west-2": {
+                "SLES15SP5": "ami-066c85d277ae33d38"
+            },
+            "eu-west-1": {
+                "SLES15SP5": "ami-028867095499bce4b"
+            },
+            "eu-west-2": {
+                "RHEL9": "ami-03d783398e1e54eb1"
+            },
+            "ap-northeast-1": {
+                "RHEL9": "ami-05ef8ea5a07946994"
+            },
+            "ap-northeast-2": {
+                "RHEL9": "ami-0f8bf550807d8d01a"
+            },
+            "ap-southeast-1": {
+                "RHEL9": "ami-0db03992e79210b9f"
+            },
+            "ap-southeast-2": {
+                "RHEL9": "ami-084fd76702fabcf2c"
+            }
         }
     },
     "Resources": {
@@ -120,19 +157,28 @@
                     "Ref": "KeyName"
                 },
                 "ImageId": {
-                    "Ref": "InstanceAMI"
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        {
+                            "Ref": "SUSEVersion"
+                        }
+                    ]
                 },
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
-                        "Fn::Sub": "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm\nyum update -y\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
+                        "Fn::Sub": "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm\ncurl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py\n# Install pip using python3\npython3 get-pip.py\nexport PATH=$PATH:/usr/local/bin\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n"
                     }
                 }
             }

--- a/Solutions/AmazonCloudWatchAgent/inline/suse.yaml
+++ b/Solutions/AmazonCloudWatchAgent/inline/suse.yaml
@@ -11,13 +11,16 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
-  InstanceAMI:
-    Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-28e07e50
+  SUSEVersion:
+    Type: String
+    AllowedValues: 
+      - SLES15SP5
+    Default: SLES15SP5
+    Description: SUSE Linux Enterprise Server version to deploy
+
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -36,6 +39,29 @@ Parameters:
 
   SubnetId:
     Type: AWS::EC2::Subnet::Id
+
+Mappings:
+  RegionMap:
+    us-east-1:
+      SLES15SP5: ami-0d62a8e6541a2d491
+    us-east-2:
+      SLES15SP5: ami-05d1f1c3db2b2eb0c
+    us-west-1:
+      SLES15SP5: ami-060034d187be82d31
+    us-west-2:
+      SLES15SP5: ami-066c85d277ae33d38
+    eu-west-1:
+      SLES15SP5: ami-028867095499bce4b
+    eu-west-2:
+      SLES15SP5: ami-03d783398e1e54eb1
+    ap-northeast-1:
+      SLES15SP5: ami-05ef8ea5a07946994
+    ap-northeast-2:
+      SLES15SP5: ami-0f8bf550807d8d01a
+    ap-southeast-1:
+      SLES15SP5: ami-0db03992e79210b9f
+    ap-southeast-2:
+      SLES15SP5: ami-084fd76702fabcf2c
 
 Resources:
   EC2Instance:
@@ -133,15 +159,21 @@ Resources:
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref IAMRole
       KeyName: !Ref KeyName
-      ImageId: !Ref InstanceAMI
+      ImageId: !FindInMap 
+        - RegionMap
+        - !Ref 'AWS::Region'
+        - !Ref SUSEVersion
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash
           rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm
-          yum update -y
+          curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py
+          # Install pip using python3
+          python3 get-pip.py
+          export PATH=$PATH:/usr/local/bin
           pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
           cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
           cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/Solutions/AmazonCloudWatchAgent/inline/ubuntu.json
+++ b/Solutions/AmazonCloudWatchAgent/inline/ubuntu.json
@@ -10,13 +10,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-6e1a0117"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/canonical/ubuntu/eks-pro/22.04/1.29/stable/current/amd64/hvm/ebs-gp2/ami-id"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -125,10 +125,11 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {

--- a/Solutions/AmazonCloudWatchAgent/inline/ubuntu.yaml
+++ b/Solutions/AmazonCloudWatchAgent/inline/ubuntu.yaml
@@ -11,13 +11,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-6e1a0117
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/eks-pro/22.04/1.29/stable/current/amd64/hvm/ebs-gp2/ami-id
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -135,8 +135,8 @@ Resources:
       KeyName: !Ref KeyName
       ImageId: !Ref InstanceAMI
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash

--- a/Solutions/AmazonCloudWatchAgent/inline/windows.json
+++ b/Solutions/AmazonCloudWatchAgent/inline/windows.json
@@ -10,13 +10,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-3703414f"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-SQL_2022_Web"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",

--- a/Solutions/AmazonCloudWatchAgent/inline/windows.yaml
+++ b/Solutions/AmazonCloudWatchAgent/inline/windows.yaml
@@ -11,13 +11,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-3703414f
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-windows-latest/Windows_Server-2022-English-Full-SQL_2022_Web
 
   IAMRole:
     Description: EC2 attached IAM role

--- a/Solutions/AmazonCloudWatchAgent/ssm/amazon_linux.json
+++ b/Solutions/AmazonCloudWatchAgent/ssm/amazon_linux.json
@@ -5,7 +5,7 @@
         "SSMKey": {
             "Description": "Name of parameter store which contains the json configuration of CWAgent.",
             "Type": "String",
-            "Default": "AmazonCloudWatch-DefaultLinuxConfigCloudFormationCreate"
+            "Default": "AmazonCloudWatch-DefaultLinuxConfigCloudFormation"
         },
         "KeyName": {
             "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instance",
@@ -15,13 +15,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-7707a10f"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -139,10 +139,12 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    }   
+                    
                 ],
                 "UserData": {
                     "Fn::Base64": {

--- a/Solutions/AmazonCloudWatchAgent/ssm/amazon_linux.yaml
+++ b/Solutions/AmazonCloudWatchAgent/ssm/amazon_linux.yaml
@@ -6,7 +6,7 @@ Parameters:
   SSMKey:
     Description: Name of parameter store which contains the json configuration of CWAgent.
     Type: String
-    Default: AmazonCloudWatch-DefaultLinuxConfigCloudFormationCreate
+    Default: AmazonCloudWatch-DefaultLinuxConfigCloudFormation
 
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
@@ -16,13 +16,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-7707a10f
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -123,8 +123,8 @@ Resources:
       KeyName: !Ref KeyName
       ImageId: !Ref InstanceAMI
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub:
           - |

--- a/Solutions/AmazonCloudWatchAgent/ssm/centos.json
+++ b/Solutions/AmazonCloudWatchAgent/ssm/centos.json
@@ -15,13 +15,16 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
-        "InstanceAMI": {
-            "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-28e07e50"
+        "CentOSVersion": {
+            "Type": "String",
+            "AllowedValues": [
+                "CentOS9"
+            ],
+            "Default": "CentOS9",
+            "Description": "CentOS version to deploy"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -40,6 +43,40 @@
         },
         "SubnetId": {
             "Type": "AWS::EC2::Subnet::Id"
+        }
+    },
+    "Mappings": {
+        "RegionMap": {
+            "us-east-1": {
+                "CentOS9": "ami-0705f7887207411ca"
+            },
+            "us-east-2": {
+                "CentOS9": "ami-0fe2c46c1dc3889fa"
+            },
+            "us-west-1": {
+                "CentOS9": "ami-0f4f63d1732fd4ef5"
+            },
+            "us-west-2": {
+                "CentOS9": "ami-00b231246df1d28de"
+            },
+            "eu-west-1": {
+                "CentOS9": "ami-05a7b8270231783b2"
+            },
+            "eu-west-2": {
+                "RHEL9": "ami-0086646e63ce5aaf1"
+            },
+            "ap-northeast-1": {
+                "RHEL9": "ami-0d8ee41b4b6f8343b"
+            },
+            "ap-northeast-2": {
+                "RHEL9": "ami-031e0786d2134adf6"
+            },
+            "ap-southeast-1": {
+                "RHEL9": "ami-0a9082a6b182a840b"
+            },
+            "ap-southeast-2": {
+                "RHEL9": "ami-05ffc8a6cb624035b"
+            }
         }
     },
     "Resources": {
@@ -134,20 +171,29 @@
                     "Ref": "KeyName"
                 },
                 "ImageId": {
-                    "Ref": "InstanceAMI"
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        {
+                            "Ref": "CentOSVersion"
+                        }
+                    ]
                 },
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
                         "Fn::Sub": [
-                            "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\nyum update -y\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
+                            "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\nyum update -y\nyum install python3 -y\ncurl -O https://bootstrap.pypa.io/get-pip.py\n# Install pip using python3\npython3 get-pip.py\nexport PATH=$PATH:/usr/local/bin\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
                             {
                                 "ssmkey": {
                                     "Ref": "SSMKey"

--- a/Solutions/AmazonCloudWatchAgent/ssm/centos.yaml
+++ b/Solutions/AmazonCloudWatchAgent/ssm/centos.yaml
@@ -16,13 +16,15 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
-  InstanceAMI:
-    Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-28e07e50
+  CentOSVersion:
+    Type: String
+    AllowedValues: 
+      - CentOS9
+    Default: CentOS9
+    Description: CentOS version to deploy
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -41,6 +43,29 @@ Parameters:
 
   SubnetId:
     Type: AWS::EC2::Subnet::Id
+
+Mappings:
+  RegionMap:
+    us-east-1:
+      CentOS9: ami-0705f7887207411ca
+    us-east-2:
+      CentOS9: ami-0fe2c46c1dc3889fa
+    us-west-1:
+      CentOS9: ami-0f4f63d1732fd4ef5
+    us-west-2:
+      CentOS9: ami-00b231246df1d28de
+    eu-west-1:
+      CentOS9: ami-05a7b8270231783b2
+    eu-west-2:
+      CentOS9: ami-0086646e63ce5aaf1
+    ap-northeast-1:
+      CentOS9: ami-0d8ee41b4b6f8343b
+    ap-northeast-2:
+      CentOS9: ami-031e0786d2134adf6
+    ap-southeast-1:
+      CentOS9: ami-0a9082a6b182a840b
+    ap-southeast-2:
+      CentOS9: ami-05ffc8a6cb624035b
 
 Resources:
   EC2Instance:
@@ -121,10 +146,13 @@ Resources:
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref IAMRole
       KeyName: !Ref KeyName
-      ImageId: !Ref InstanceAMI
+      ImageId: !FindInMap 
+        - RegionMap
+        - !Ref 'AWS::Region'
+        - !Ref CentOSVersion
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub:
           - |
@@ -132,6 +160,11 @@ Resources:
             rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/centos/amd64/latest/amazon-cloudwatch-agent.rpm
             /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
             yum update -y
+            yum install python3 -y
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            # Install pip using python3
+            python3 get-pip.py
+            export PATH=$PATH:/usr/local/bin
             pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
             cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
             cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/Solutions/AmazonCloudWatchAgent/ssm/debian.json
+++ b/Solutions/AmazonCloudWatchAgent/ssm/debian.json
@@ -15,13 +15,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-6e1a0117"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/debian/release/10/latest/amd64"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -139,15 +139,16 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
                         "Fn::Sub": [
-                            "#!/bin/bash\nwget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb\ndpkg -i /tmp/amazon-cloudwatch-agent.deb\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\napt-get update -y\napt-get install -y python3 pipx && pipx ensurepath\npipx install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
+                            "#!/bin/bash\nwget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb\nsudo dpkg -i /tmp/amazon-cloudwatch-agent.deb\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\nwget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz\nsudo apt-get update -y\nsudo apt-get install -y python3-pip python3-venv\n\n# Create and activate a virtual environment\npython3 -m venv /opt/aws/virtualenv\nsource /opt/aws/virtualenv/bin/activate\n\n# Install the bootstrap package\npip install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz\n\n# Create necessary symlinks\nsudo mkdir -p /opt/aws/bin\nsudo ln -s /opt/aws/virtualenv/bin/cfn-* /opt/aws/bin/\n\n# Run cfn-init\n/opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\n/opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
                             {
                                 "ssmkey": {
                                     "Ref": "SSMKey"

--- a/Solutions/AmazonCloudWatchAgent/ssm/debian.yaml
+++ b/Solutions/AmazonCloudWatchAgent/ssm/debian.yaml
@@ -16,13 +16,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-6e1a0117
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/debian/release/10/latest/amd64
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -123,20 +123,33 @@ Resources:
       KeyName: !Ref KeyName
       ImageId: !Ref InstanceAMI
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub:
           - |
             #!/bin/bash
             wget https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb
-            dpkg -i /tmp/amazon-cloudwatch-agent.deb
+            sudo dpkg -i /tmp/amazon-cloudwatch-agent.deb
             /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
-            apt-get update -y
-            apt-get install -y python3 pipx && pipx ensurepath
-            pipx install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
-            cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
-            cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
+            wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz -O /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+            sudo apt-get update -y
+            sudo apt-get install -y python3-pip python3-venv
+
+            # Create and activate a virtual environment
+            python3 -m venv /opt/aws/virtualenv
+            source /opt/aws/virtualenv/bin/activate
+
+            # Install the bootstrap package
+            pip install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+
+            # Create necessary symlinks
+            sudo mkdir -p /opt/aws/bin
+            sudo ln -s /opt/aws/virtualenv/bin/cfn-* /opt/aws/bin/
+
+            # Run cfn-init
+            /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
+            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}
           - ssmkey: !Ref SSMKey
 
   InstanceSecurityGroup:

--- a/Solutions/AmazonCloudWatchAgent/ssm/redhat.json
+++ b/Solutions/AmazonCloudWatchAgent/ssm/redhat.json
@@ -15,13 +15,16 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
-        "InstanceAMI": {
-            "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-28e07e50"
+        "RHELVersion": {
+            "Type": "String",
+            "AllowedValues": [
+                "RHEL9"
+            ],
+            "Default": "RHEL9",
+            "Description": "RHEL version to deploy"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -42,6 +45,42 @@
             "Type": "AWS::EC2::Subnet::Id"
         }
     },
+
+    "Mappings": {
+        "RegionMap": {
+            "us-east-1": {
+                "RHEL9": "ami-0fb13bb53494158e9"
+            },
+            "us-east-2": {
+                "RHEL9": "ami-0aeea2f24f6d3ba32"
+            },
+            "us-west-1": {
+                "RHEL9": "ami-068c2af1200ef7356"
+            },
+            "us-west-2": {
+                "RHEL9": "ami-0367f2b5c3d1ef960"
+            },
+            "eu-west-1": {
+                "RHEL9": "ami-0f0f1c02e5e4d9d9f"
+            },
+            "eu-west-2": {
+                "RHEL9": "ami-02b1e3a99e36afd1a"
+            },
+            "ap-northeast-1": {
+                "RHEL9": "ami-0eade93757ef7bb6c"
+            },
+            "ap-northeast-2": {
+                "RHEL9": "ami-097698b6cd8164ea2"
+            },
+            "ap-southeast-1": {
+                "RHEL9": "ami-0b9521fddc9871128"
+            },
+            "ap-southeast-2": {
+                "RHEL9": "ami-0eea634029e7b983c"
+            }
+        }
+    },
+
     "Resources": {
         "EC2Instance": {
             "CreationPolicy": {
@@ -134,20 +173,29 @@
                     "Ref": "KeyName"
                 },
                 "ImageId": {
-                    "Ref": "InstanceAMI"
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        {
+                            "Ref": "RHELVersion"
+                        }
+                    ]
                 },
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
                         "Fn::Sub": [
-                            "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\nyum update -y\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
+                            "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\nyum update -y\nyum install python3 -y\ncurl -O https://bootstrap.pypa.io/get-pip.py\n# Install pip using python3\npython3 get-pip.py\nexport PATH=$PATH:/usr/local/bin\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
                             {
                                 "ssmkey": {
                                     "Ref": "SSMKey"

--- a/Solutions/AmazonCloudWatchAgent/ssm/redhat.yaml
+++ b/Solutions/AmazonCloudWatchAgent/ssm/redhat.yaml
@@ -16,13 +16,15 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
-  InstanceAMI:
-    Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-28e07e50
+  RHELVersion:
+    Type: String
+    AllowedValues: 
+      - RHEL9
+    Default: RHEL9
+    Description: RHEL version to deploy
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -41,6 +43,31 @@ Parameters:
 
   SubnetId:
     Type: AWS::EC2::Subnet::Id
+
+Mappings:
+  RegionMap:
+    us-east-1:
+      RHEL9: ami-0fb13bb53494158e9
+    us-east-2:
+      RHEL9: ami-0aeea2f24f6d3ba32
+    us-west-1:
+      RHEL9: ami-068c2af1200ef7356
+    us-west-2:
+      RHEL9: ami-0367f2b5c3d1ef960
+    eu-west-1:
+      RHEL9: ami-0e28d6c0c65e7f82f
+    eu-west-2:
+      RHEL9: ami-02b1e3a99e36afd1a
+    ap-northeast-1:
+      RHEL9: ami-0eade93757ef7bb6c
+    ap-northeast-2:
+      RHEL9: ami-097698b6cd8164ea2
+    ap-southeast-1:
+      RHEL9: ami-0b9521fddc9871128
+    ap-southeast-2:
+      RHEL9: ami-0eea634029e7b983c
+    
+    
 
 Resources:
   EC2Instance:
@@ -121,10 +148,13 @@ Resources:
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref IAMRole
       KeyName: !Ref KeyName
-      ImageId: !Ref InstanceAMI
+      ImageId: !FindInMap 
+        - RegionMap
+        - !Ref 'AWS::Region'
+        - !Ref RHELVersion
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub:
           - |
@@ -132,6 +162,11 @@ Resources:
             rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
             /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
             yum update -y
+            yum install python3 -y
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            # Install pip using python3
+            python3 get-pip.py
+            export PATH=$PATH:/usr/local/bin
             pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
             cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
             cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/Solutions/AmazonCloudWatchAgent/ssm/suse.json
+++ b/Solutions/AmazonCloudWatchAgent/ssm/suse.json
@@ -15,13 +15,16 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
-        "InstanceAMI": {
-            "Description": "Managed AMI ID for EC2 Instance, Suse 12",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-0d85a662720db9789"
+        "SUSEVersion": {
+            "Type": "String",
+            "AllowedValues": [
+                "SLES15SP5"
+            ],
+            "Default": "SLES15SP5",
+            "Description": "SUSE Linux Enterprise Server version to deploy"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -32,7 +35,7 @@
         "SSHLocation": {
             "Description": "The IP address range that can be used to SSH to the EC2 instances",
             "Type": "String",
-            "Default": "192.168.1.0/0",
+            "Default": "0.0.0.0/0",
             "MinLength": "9",
             "MaxLength": "18",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
@@ -40,6 +43,40 @@
         },
         "SubnetId": {
             "Type": "AWS::EC2::Subnet::Id"
+        }
+    },
+    "Mappings": {
+        "RegionMap": {
+            "us-east-1": {
+                "SLES15SP5": "ami-0d62a8e6541a2d491"
+            },
+            "us-east-2": {
+                "SLES15SP5": "ami-05d1f1c3db2b2eb0c"
+            },
+            "us-west-1": {
+                "SLES15SP5": "ami-060034d187be82d31"
+            },
+            "us-west-2": {
+                "SLES15SP5": "ami-066c85d277ae33d38"
+            },
+            "eu-west-1": {
+                "SLES15SP5": "ami-028867095499bce4b"
+            },
+            "eu-west-2": {
+                "RHEL9": "ami-03d783398e1e54eb1"
+            },
+            "ap-northeast-1": {
+                "RHEL9": "ami-05ef8ea5a07946994"
+            },
+            "ap-northeast-2": {
+                "RHEL9": "ami-0f8bf550807d8d01a"
+            },
+            "ap-southeast-1": {
+                "RHEL9": "ami-0db03992e79210b9f"
+            },
+            "ap-southeast-2": {
+                "RHEL9": "ami-084fd76702fabcf2c"
+            }
         }
     },
     "Resources": {
@@ -134,20 +171,29 @@
                     "Ref": "KeyName"
                 },
                 "ImageId": {
-                    "Ref": "InstanceAMI"
+                    "Fn::FindInMap": [
+                        "RegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        {
+                            "Ref": "SUSEVersion"
+                        }
+                    ]
                 },
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {
                         "Fn::Sub": [
-                            "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\nyum update -y\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
+                            "#!/bin/bash\nrpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s\ncurl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py\n# Install pip using python3\npython3 get-pip.py\nexport PATH=$PATH:/usr/local/bin\npip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz\ncfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default\ncfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}\n",
                             {
                                 "ssmkey": {
                                     "Ref": "SSMKey"

--- a/Solutions/AmazonCloudWatchAgent/ssm/suse.yaml
+++ b/Solutions/AmazonCloudWatchAgent/ssm/suse.yaml
@@ -16,13 +16,16 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
-  InstanceAMI:
-    Description: Managed AMI ID for EC2 Instance, Suse 12
-    Type: AWS::EC2::Image::Id
-    Default: ami-0d85a662720db9789
+  SUSEVersion:
+    Type: String
+    AllowedValues: 
+      - SLES15SP5
+    Default: SLES15SP5
+    Description: SUSE Linux Enterprise Server version to deploy
+
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -33,7 +36,7 @@ Parameters:
   SSHLocation:
     Description: The IP address range that can be used to SSH to the EC2 instances
     Type: String
-    Default: 192.168.1.0/0
+    Default: 0.0.0.0/0
     MinLength: "9"
     MaxLength: "18"
     AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
@@ -41,6 +44,29 @@ Parameters:
 
   SubnetId:
     Type: AWS::EC2::Subnet::Id
+
+Mappings:
+  RegionMap:
+    us-east-1:
+      SLES15SP5: ami-0d62a8e6541a2d491
+    us-east-2:
+      SLES15SP5: ami-05d1f1c3db2b2eb0c
+    us-west-1:
+      SLES15SP5: ami-060034d187be82d31
+    us-west-2:
+      SLES15SP5: ami-066c85d277ae33d38
+    eu-west-1:
+      SLES15SP5: ami-028867095499bce4b
+    eu-west-2:
+      SLES15SP5: ami-03d783398e1e54eb1
+    ap-northeast-1:
+      SLES15SP5: ami-05ef8ea5a07946994
+    ap-northeast-2:
+      SLES15SP5: ami-0f8bf550807d8d01a
+    ap-southeast-1:
+      SLES15SP5: ami-0db03992e79210b9f
+    ap-southeast-2:
+      SLES15SP5: ami-084fd76702fabcf2c
 
 Resources:
   EC2Instance:
@@ -121,17 +147,23 @@ Resources:
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref IAMRole
       KeyName: !Ref KeyName
-      ImageId: !Ref InstanceAMI
+      ImageId: !FindInMap 
+        - RegionMap
+        - !Ref 'AWS::Region'
+        - !Ref SUSEVersion
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub:
           - |
             #!/bin/bash
             rpm -Uvh https://s3.amazonaws.com/amazoncloudwatch-agent/suse/amd64/latest/amazon-cloudwatch-agent.rpm
             /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ssmkey} -s
-            yum update -y
+            curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py
+            # Install pip using python3
+            python3 get-pip.py
+            export PATH=$PATH:/usr/local/bin	
             pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
             cfn-init -v --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region} --configsets default
             cfn-signal -e $? --stack ${AWS::StackId} --resource EC2Instance --region ${AWS::Region}

--- a/Solutions/AmazonCloudWatchAgent/ssm/ubuntu.json
+++ b/Solutions/AmazonCloudWatchAgent/ssm/ubuntu.json
@@ -15,13 +15,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-6e1a0117"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/canonical/ubuntu/eks-pro/22.04/1.29/stable/current/amd64/hvm/ebs-gp2/ami-id"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",
@@ -139,10 +139,11 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
-                    }
+                        
+                        "Fn::GetAtt" : [ "InstanceSecurityGroup", "GroupId" ]
+                    } 
                 ],
                 "UserData": {
                     "Fn::Base64": {

--- a/Solutions/AmazonCloudWatchAgent/ssm/ubuntu.yaml
+++ b/Solutions/AmazonCloudWatchAgent/ssm/ubuntu.yaml
@@ -16,13 +16,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-6e1a0117
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/eks-pro/22.04/1.29/stable/current/amd64/hvm/ebs-gp2/ami-id
 
   IAMRole:
     Description: EC2 attached IAM role
@@ -123,8 +123,8 @@ Resources:
       KeyName: !Ref KeyName
       ImageId: !Ref InstanceAMI
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       UserData: !Base64
         Fn::Sub:
           - |

--- a/Solutions/AmazonCloudWatchAgent/ssm/windows.json
+++ b/Solutions/AmazonCloudWatchAgent/ssm/windows.json
@@ -5,7 +5,7 @@
         "SSMKey": {
             "Description": "Name of parameter store which contains the json configuration of CWAgent.",
             "Type": "String",
-            "Default": "AmazonCloudWatch-DefaultLinuxConfigCloudFormation"
+            "Default": "AmazonCloudWatch-DefaultWindowsConfigCloudFormation"
         },
         "KeyName": {
             "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instance",
@@ -15,13 +15,13 @@
         "InstanceType": {
             "Description": "EC2 instance type",
             "Type": "String",
-            "Default": "m4.2xlarge",
+            "Default": "t3.medium",
             "ConstraintDescription": "must be a valid EC2 instance type."
         },
         "InstanceAMI": {
             "Description": "Managed AMI ID for EC2 Instance",
-            "Type": "AWS::EC2::Image::Id",
-            "Default": "ami-3703414f"
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-SQL_2022_Web"
         },
         "IAMRole": {
             "Description": "EC2 attached IAM role",

--- a/Solutions/AmazonCloudWatchAgent/ssm/windows.yaml
+++ b/Solutions/AmazonCloudWatchAgent/ssm/windows.yaml
@@ -6,7 +6,7 @@ Parameters:
   SSMKey:
     Description: Name of parameter store which contains the json configuration of CWAgent.
     Type: String
-    Default: AmazonCloudWatch-DefaultLinuxConfigCloudFormation
+    Default: AmazonCloudWatch-DefaultWindowsConfigCloudFormation
 
   KeyName:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
@@ -16,13 +16,13 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: m4.2xlarge
+    Default: t3.medium
     ConstraintDescription: must be a valid EC2 instance type.
 
   InstanceAMI:
     Description: Managed AMI ID for EC2 Instance
-    Type: AWS::EC2::Image::Id
-    Default: ami-3703414f
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-windows-latest/Windows_Server-2022-English-Full-SQL_2022_Web
 
   IAMRole:
     Description: EC2 attached IAM role


### PR DESCRIPTION
*Issue #, if available:* [Issue 397](https://github.com/aws-cloudformation/aws-cloudformation-templates/issues/397)

*Description of changes:*

- **For Amazon LInux, Windows, Debian and Ubuntu** : Instead of hardcoded AMI IDs, updated the templates to use SSM parameter values for AMIs.
- **CentOs, SuSe and RedHat**: There are no SSM parameters available. Hence, added a mappings file to use latest available AMIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
