### PR TITLE
error in InstanceWithCfnInit.yaml -- forget to init the cfn-init

### DIFF
--- a/EC2/InstanceWithCfnInit.yaml
+++ b/EC2/InstanceWithCfnInit.yaml
@@ -63,4 +63,5 @@ Resources:
       UserData: !Base64
         Fn::Sub: |-
           #!/bin/bash
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}


### PR DESCRIPTION
add cfn-init codes
/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}

*Issue #, if available:*
forget to init the cfn-init

*Description of changes:*
add cfn-init codes
/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Instance --region ${AWS::Region}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
