### PR TITLE
Updated templates to use latest CodeBuild image, dotnet runtime and pipeline trigger mechanism

### DIFF
--- a/Solutions/CodeBuildAndCodePipeline/cloudformation-codebuild-template.json
+++ b/Solutions/CodeBuildAndCodePipeline/cloudformation-codebuild-template.json
@@ -5,7 +5,7 @@
         "DockerImage": {
             "Description": "Docker image to use for the build phase",
             "Type": "String",
-            "Default": "aws/codebuild/standard:6.0"
+            "Default": "aws/codebuild/standard:7.0"
         }
     },
     "Resources": {

--- a/Solutions/CodeBuildAndCodePipeline/cloudformation-codebuild-template.yaml
+++ b/Solutions/CodeBuildAndCodePipeline/cloudformation-codebuild-template.yaml
@@ -6,7 +6,7 @@ Parameters:
   DockerImage:
     Description: Docker image to use for the build phase
     Type: String
-    Default: aws/codebuild/standard:6.0
+    Default: aws/codebuild/standard:7.0
 
 Resources:
   CodeCommitRepo:

--- a/Solutions/CodeBuildAndCodePipeline/cloudformation-codepipeline-template.json
+++ b/Solutions/CodeBuildAndCodePipeline/cloudformation-codepipeline-template.json
@@ -127,6 +127,121 @@
                 ]
             }
         },
+        "EventRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "events.amazonaws.com"
+                                ]
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "eb-pipeline-execution",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "codepipeline:StartPipelineExecution",
+                                    "Resource": {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:aws:codepipeline:",
+                                                {
+                                                    "Ref": "AWS::Region"
+                                                },
+                                                ":",
+                                                {
+                                                    "Ref": "AWS::AccountId"
+                                                },
+                                                ":",
+                                                {
+                                                    "Ref": "Pipeline"
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "EventRule": {
+            "Type": "AWS::Events::Rule",
+            "Properties": {
+                "EventPattern": {
+                    "source": [
+                        "aws.codecommit"
+                    ],
+                    "detail-type": [
+                        "CodeCommit Repository State Change"
+                    ],
+                    "resources": [
+                        {
+                            "Fn::ImportValue": {
+                                "Fn::Sub": "${CodeBuildStack}-CodeCommitArn"
+                            }
+                        }
+                    ],
+                    "detail": {
+                        "event": [
+                            "referenceCreated",
+                            "referenceUpdated"
+                        ],
+                        "referenceType": [
+                            "branch"
+                        ],
+                        "referenceName": [
+                            "main"
+                        ]
+                    }
+                },
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    "arn:aws:codepipeline:",
+                                    {
+                                        "Ref": "AWS::Region"
+                                    },
+                                    ":",
+                                    {
+                                        "Ref": "AWS::AccountId"
+                                    },
+                                    ":",
+                                    {
+                                        "Ref": "Pipeline"
+                                    }
+                                ]
+                            ]
+                        },
+                        "RoleArn": {
+                            "Fn::GetAtt": [
+                                "EventRole",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "codepipeline-Pipeline"
+                    }
+                ]
+            }
+        },
         "Pipeline": {
             "Type": "AWS::CodePipeline::Pipeline",
             "Properties": {
@@ -166,7 +281,8 @@
                                             "Fn::Sub": "${CodeBuildStack}-CodeCommitName"
                                         }
                                     },
-                                    "BranchName": "main"
+                                    "BranchName": "main",
+                                    "PollForSourceChanges": false
                                 },
                                 "OutputArtifacts": [
                                     {

--- a/Solutions/CodeBuildAndCodePipeline/cloudformation-codepipeline-template.yaml
+++ b/Solutions/CodeBuildAndCodePipeline/cloudformation-codepipeline-template.yaml
@@ -74,6 +74,54 @@ Resources:
                   - !ImportValue
                     Fn::Sub: ${CodeBuildStack}-AppDeployArn
 
+  EventRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        -
+          PolicyName: eb-pipeline-execution
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action: codepipeline:StartPipelineExecution
+                Resource: !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline ] ] 
+  EventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.codecommit
+        detail-type:
+          - 'CodeCommit Repository State Change'
+        resources:
+          - !ImportValue
+              Fn::Sub: ${CodeBuildStack}-CodeCommitArn
+        detail:
+          event:
+            - referenceCreated
+            - referenceUpdated
+          referenceType:
+            - branch
+          referenceName:
+            - main
+      Targets:
+        -
+          Arn: 
+            !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref Pipeline ] ]
+          RoleArn: !GetAtt EventRole.Arn
+          Id: codepipeline-Pipeline
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
@@ -97,6 +145,7 @@ Resources:
                 RepositoryName: !ImportValue
                   Fn::Sub: ${CodeBuildStack}-CodeCommitName
                 BranchName: main
+                PollForSourceChanges: false
               OutputArtifacts:
                 - Name: Source
         - Name: Build-AppBuild

--- a/Solutions/CodeBuildAndCodePipeline/codebuild-app-build.yml
+++ b/Solutions/CodeBuildAndCodePipeline/codebuild-app-build.yml
@@ -7,6 +7,10 @@ env:
     RelativePathToTestProject: "serverless-test-samples/dotnet-test-samples/apigw-lambda-ddb/tests/ApiTests.UnitTest"
     OutputLocation: "output/src/lambda/sample-lambda-code.zip"
 phases:
+  install:
+    runtime-versions:
+      dotnet: 8.0
+
   pre_build:
     commands: 
       - git clone $SampleRepository

--- a/Solutions/CodeBuildAndCodePipeline/readme.md
+++ b/Solutions/CodeBuildAndCodePipeline/readme.md
@@ -13,7 +13,7 @@ required menus to deploy the jobs and pipelines through the AWS console.
 
 This example contains two CloudFormation templates.
 
-### codebuild-template.yml
+### codebuild-template.yaml
 
 This template must be deployed first as the cloudformation-codepipeline-template
 has dependencies on the output of this template. This template deploys the
@@ -49,8 +49,8 @@ deployment.
 ```
 codebuild_stackname="cf-sample-codebuild"
 codepipeline_stackName="cf-sample-codepipeline"
-codebuild_template="cloudformation-codebuild-template.yml"
-codepipeline_template="cloudformation-codepipeline-template.yml"
+codebuild_template="cloudformation-codebuild-template.yaml"
+codepipeline_template="cloudformation-codepipeline-template.yaml"
 ```
 
 2. Deploy the CodeBuild cloud formation template
@@ -104,8 +104,8 @@ Application Architect
 ```
 codebuild_stackname="cf-sample-codebuild"
 codepipeline_stackName="cf-sample-codepipeline"
-codebuild_template="cloudformation-codebuild-template.yml"
-codepipeline_template="cloudformation-codepipeline-template.yml"
+codebuild_template="cloudformation-codebuild-template.yaml"
+codepipeline_template="cloudformation-codepipeline-template.yaml"
 ```
 
 #### Creating Deployment Resources


### PR DESCRIPTION

*Issue #, if available:* [#459](https://github.com/aws-cloudformation/aws-cloudformation-templates/issues/459)

*Description of changes:*

- Migrated CodePipeline trigger mechanism to use EventBridge events as per the official [documentation](https://docs.aws.amazon.com/codepipeline/latest/userguide/update-change-detection.html) recommendation.
- Updated codebuild image parameter to use latest 7.0 version
- Updated buildspec file to use dotnet:8.0 runtime
- Fixed yaml extensions in README file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
