### PR TITLE
[Fix:464] Replaced imports with parameters and removed custom resource.

### DIFF
--- a/Solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.json
+++ b/Solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.json
@@ -23,6 +23,21 @@
             ],
             "Default": "dev"
         },
+        "VpcId": {
+            "Description": "Please specify the VPC ID.",
+            "Type": "AWS::EC2::VPC::Id",
+            "ConstraintDescription": "Must be a valid VPC ID"
+        },
+        "PublicSubnetId1": {
+            "Description": "Please specify first public subnet ID.",
+            "Type": "AWS::EC2::Subnet::Id",
+            "ConstraintDescription": "Must be a valid subnet ID in the selected VPC"
+        },
+        "PublicSubnetId2": {
+            "Description": "Please specify second public subnet ID.",
+            "Type": "AWS::EC2::Subnet::Id",
+            "ConstraintDescription": "Must be a valid subnet ID in the selected VPC"
+        },
         "AppName": {
             "Description": "Application environment name.",
             "Type": "String",
@@ -96,7 +111,7 @@
         "KeyPairName": {
             "Description": "EC2 KeyPair.",
             "Type": "AWS::EC2::KeyPair::KeyName",
-            "Default": "keypair"
+            "ConstraintDescription": "Must be the name of an existing EC2 KeyPair"
         },
         "BootVolSize": {
             "Description": "EC2 Instance Boot volume size.",
@@ -303,11 +318,6 @@
             "Type": "String",
             "Default": "/health.html"
         },
-        "LambdaFunctionVersion": {
-            "Description": "AWS Lambda@Edge function version.",
-            "Type": "String",
-            "Default": "1"
-        },
         "LoggingBucketVersioning": {
             "Description": "The versioning state of an Amazon S3 bucket. If you enable versioning, you must suspend versioning to disable it.",
             "Type": "String",
@@ -479,12 +489,20 @@
                 "BucketName": {
                     "Fn::Sub": "${AppName}-logging-${Environment}-${AWS::AccountId}-${AWS::Region}"
                 },
+                "OwnershipControls": {
+                    "Rules": [
+                        {
+                            "ObjectOwnership": "ObjectWriter"
+                        }
+                    ]
+                },
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": true,
                     "BlockPublicPolicy": true,
                     "IgnorePublicAcls": true,
                     "RestrictPublicBuckets": true
                 },
+                "AccessControl": "LogDeliveryWrite",
                 "BucketEncryption": {
                     "ServerSideEncryptionConfiguration": [
                         {
@@ -558,23 +576,11 @@
                 "ImageId": {
                     "Ref": "EC2ImageId"
                 },
-                "AvailabilityZone": {
-                    "Fn::Select": [
-                        "0",
-                        {
-                            "Fn::GetAZs": {
-                                "Ref": "AWS::Region"
-                            }
-                        }
-                    ]
-                },
                 "InstanceType": {
                     "Ref": "EC2InstanceType"
                 },
                 "SubnetId": {
-                    "Fn::ImportValue": {
-                        "Fn::Sub": "${AppName}-vpc-${Environment}-PublicSubnet1ID"
-                    }
+                    "Ref": "PublicSubnetId1"
                 },
                 "BlockDeviceMappings": [
                     {
@@ -621,9 +627,7 @@
             "Properties": {
                 "GroupDescription": "EC2 Instance Security Group",
                 "VpcId": {
-                    "Fn::ImportValue": {
-                        "Fn::Sub": "${AppName}-vpc-${Environment}-VPC-ID"
-                    }
+                    "Ref": "VpcId"
                 },
                 "Tags": [
                     {
@@ -689,14 +693,10 @@
                 ],
                 "Subnets": [
                     {
-                        "Fn::ImportValue": {
-                            "Fn::Sub": "${AppName}-vpc-${Environment}-PublicSubnet1ID"
-                        }
+                        "Ref": "PublicSubnetId1"
                     },
                     {
-                        "Fn::ImportValue": {
-                            "Fn::Sub": "${AppName}-vpc-${Environment}-PublicSubnet2ID"
-                        }
+                        "Ref": "PublicSubnetId2"
                     }
                 ],
                 "SecurityGroups": [
@@ -772,9 +772,7 @@
                 },
                 "Protocol": "HTTP",
                 "VpcId": {
-                    "Fn::ImportValue": {
-                        "Fn::Sub": "${AppName}-vpc-${Environment}-VPC-ID"
-                    }
+                    "Ref": "VpcId"
                 },
                 "Tags": [
                     {
@@ -807,7 +805,7 @@
                 "LoadBalancerArn": {
                     "Ref": "OriginALB"
                 },
-                "Port": "443",
+                "Port": 443,
                 "Protocol": "HTTPS",
                 "Certificates": [
                     {
@@ -850,9 +848,7 @@
             "Properties": {
                 "GroupDescription": "Allow external access to ALB",
                 "VpcId": {
-                    "Fn::ImportValue": {
-                        "Fn::Sub": "${AppName}-vpc-${Environment}-VPC-ID"
-                    }
+                    "Ref": "VpcId"
                 },
                 "Tags": [
                     {
@@ -876,9 +872,9 @@
                 "GroupId": {
                     "Ref": "ALBExternalAccessSG"
                 },
-                "ToPort": "443",
+                "ToPort": 443,
                 "IpProtocol": "tcp",
-                "FromPort": "443",
+                "FromPort": 443,
                 "CidrIp": "0.0.0.0/0"
             }
         },
@@ -888,9 +884,9 @@
                 "GroupId": {
                     "Ref": "ALBExternalAccessSG"
                 },
-                "ToPort": "80",
+                "ToPort": 80,
                 "IpProtocol": "tcp",
-                "FromPort": "80",
+                "FromPort": 80,
                 "CidrIp": "0.0.0.0/0"
             }
         },
@@ -900,9 +896,9 @@
                 "GroupId": {
                     "Ref": "ALBExternalAccessSG"
                 },
-                "ToPort": "8080",
+                "ToPort": 8080,
                 "IpProtocol": "tcp",
-                "FromPort": "8080",
+                "FromPort": 8080,
                 "DestinationSecurityGroupId": {
                     "Ref": "EC2InstanceSG"
                 }
@@ -929,8 +925,8 @@
                                 "Ref": "OriginALB"
                             },
                             "CustomOriginConfig": {
-                                "HTTPPort": "80",
-                                "HTTPSPort": "443",
+                                "HTTPPort": 80,
+                                "HTTPSPort": 443,
                                 "OriginProtocolPolicy": {
                                     "Ref": "OriginProtocolPolicy"
                                 },
@@ -1061,49 +1057,11 @@
             }
         },
         "LambdaEdgeVersion": {
-            "Type": "Custom::LambdaVersion",
+            "Type": "AWS::Lambda::Version",
             "Properties": {
-                "ServiceToken": {
-                    "Fn::GetAtt": [
-                        "LambdaEdgeVersionFunction",
-                        "Arn"
-                    ]
-                },
                 "FunctionName": {
                     "Ref": "LambdaEdgeFunction"
-                },
-                "LambdaCodeVersion": {
-                    "Ref": "LambdaFunctionVersion"
                 }
-            }
-        },
-        "LambdaEdgeVersionFunction": {
-            "Type": "AWS::Lambda::Function",
-            "Metadata": {
-                "guard": {
-                    "SuppressedRules": [
-                        "LAMBDA_INSIDE_VPC"
-                    ]
-                }
-            },
-            "Properties": {
-                "Description": "A custom Lambda@Edge Version function",
-                "FunctionName": {
-                    "Fn::Sub": "${AppName}-lambda-edge-version-${Environment}"
-                },
-                "Handler": "index.handler",
-                "Role": {
-                    "Fn::GetAtt": [
-                        "LambdaEdgeIAMRole",
-                        "Arn"
-                    ]
-                },
-                "MemorySize": 128,
-                "Timeout": 30,
-                "Code": {
-                    "ZipFile": "var AWS = require('aws-sdk');\nvar response = require('cfn-response');\nexports.handler = (event, context) => {\n  console.log(\"Request received:\\n\", JSON.stringify(event));\n  if (event.RequestType == 'Delete') {\n    return response.send(event, context, response.SUCCESS);\n  }\n  var lambda = new AWS.Lambda();\n  lambda.publishVersion({FunctionName: event.ResourceProperties.FunctionName}).promise().then((data) => {\n    return response.send(event, context, response.SUCCESS, {Version: data.Version}, data.FunctionArn);\n  }).catch((e) => {\n    return response.send(event, context, response.FAILED, e);\n  });\n};\n"
-                },
-                "Runtime": "nodejs20.x"
             }
         }
     },

--- a/Solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
+++ b/Solutions/CloudFrontCustomOriginLambda@Edge/CloudFront.yaml
@@ -20,6 +20,22 @@ Parameters:
       - qa
     Default: dev
 
+  VpcId:
+    Description: Please specify the VPC ID.
+    Type: AWS::EC2::VPC::Id
+    ConstraintDescription: "Must be a valid VPC ID"
+
+  PublicSubnetId1:
+    Description: Please specify first public subnet ID.
+    Type: AWS::EC2::Subnet::Id
+    ConstraintDescription: "Must be a valid subnet ID in the selected VPC"
+  
+  PublicSubnetId2:
+    Description: Please specify second public subnet ID.
+    Type: AWS::EC2::Subnet::Id
+    ConstraintDescription: "Must be a valid subnet ID in the selected VPC"
+
+    
   AppName:
     Description: Application environment name.
     Type: String
@@ -89,8 +105,8 @@ Parameters:
 
   KeyPairName:
     Description: EC2 KeyPair.
-    Type: AWS::EC2::KeyPair::KeyName
-    Default: keypair
+    Type: AWS::EC2::KeyPair::KeyName    
+    ConstraintDescription: "Must be the name of an existing EC2 KeyPair"
 
   BootVolSize:
     Description: EC2 Instance Boot volume size.
@@ -283,11 +299,6 @@ Parameters:
     Type: String
     Default: /health.html
 
-  LambdaFunctionVersion:
-    Description: AWS Lambda@Edge function version.
-    Type: String
-    Default: "1"
-
   LoggingBucketVersioning:
     Description: The versioning state of an Amazon S3 bucket. If you enable versioning, you must suspend versioning to disable it.
     Type: String
@@ -405,11 +416,15 @@ Resources:
           - S3_BUCKET_LOGGING_ENABLED
     Properties:
       BucketName: !Sub ${AppName}-logging-${Environment}-${AWS::AccountId}-${AWS::Region}
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      AccessControl: LogDeliveryWrite
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -448,13 +463,8 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref EC2ImageId
-      AvailabilityZone: !Select
-        - "0"
-        - !GetAZs
-          Ref: AWS::Region
       InstanceType: !Ref EC2InstanceType
-      SubnetId: !ImportValue
-        Fn::Sub: ${AppName}-vpc-${Environment}-PublicSubnet1ID
+      SubnetId: !Ref PublicSubnetId1
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -475,8 +485,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: EC2 Instance Security Group
-      VpcId: !ImportValue
-        Fn::Sub: ${AppName}-vpc-${Environment}-VPC-ID
+      VpcId: !Ref VpcId
       Tags:
         - Key: Name
           Value: !Sub ${AppName}-${Environment}-ec2-instance-SG
@@ -508,10 +517,8 @@ Resources:
         - Key: routing.http2.enabled
           Value: !Ref ALBAttributeRoutingHttp2
       Subnets:
-        - !ImportValue
-          Fn::Sub: ${AppName}-vpc-${Environment}-PublicSubnet1ID
-        - !ImportValue
-          Fn::Sub: ${AppName}-vpc-${Environment}-PublicSubnet2ID
+        - !Ref PublicSubnetId1
+        - !Ref PublicSubnetId2
       SecurityGroups:
         - !Ref ALBExternalAccessSG
       Tags:
@@ -542,8 +549,7 @@ Resources:
           Port: !Ref OriginALBTGPort
       Port: !Ref OriginALBTGPort
       Protocol: HTTP
-      VpcId: !ImportValue
-        Fn::Sub: ${AppName}-vpc-${Environment}-VPC-ID
+      VpcId: !Ref VpcId
       Tags:
         - Key: Name
           Value: !Sub ${AppName}-${Environment}-alb-tg
@@ -558,8 +564,8 @@ Resources:
       DefaultActions:
         - TargetGroupArn: !Ref OriginALBTG
           Type: forward
-      LoadBalancerArn: !Ref OriginALB
-      Port: "443"
+      LoadBalancerArn: !Ref OriginALB      
+      Port: 443
       Protocol: HTTPS
       Certificates:
         - CertificateArn: !Sub arn:${AWS::Partition}:acm:${AWS::Region}:${AWS::AccountId}:certificate/${ACMCertificateIdentifier}
@@ -585,8 +591,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Allow external access to ALB
-      VpcId: !ImportValue
-        Fn::Sub: ${AppName}-vpc-${Environment}-VPC-ID
+      VpcId: !Ref VpcId
       Tags:
         - Key: Name
           Value: !Sub ${AppName}-${Environment}-alb-external-access-ingrees-SG
@@ -598,18 +603,18 @@ Resources:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !Ref ALBExternalAccessSG
-      ToPort: "443"
+      ToPort: 443
       IpProtocol: tcp
-      FromPort: "443"
+      FromPort: 443
       CidrIp: 0.0.0.0/0
 
   HTTPTcpIn:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !Ref ALBExternalAccessSG
-      ToPort: "80"
+      ToPort: 80
       IpProtocol: tcp
-      FromPort: "80"
+      FromPort: 80
       CidrIp: 0.0.0.0/0
 
   # SECURITY GROUP EGRESS
@@ -617,9 +622,9 @@ Resources:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
       GroupId: !Ref ALBExternalAccessSG
-      ToPort: "8080"
+      ToPort: 8080
       IpProtocol: tcp
-      FromPort: "8080"
+      FromPort: 8080
       DestinationSecurityGroupId: !Ref EC2InstanceSG
 
   # CLOUDFRONT DISTRIBUTION
@@ -635,8 +640,8 @@ Resources:
           - DomainName: !GetAtt OriginALB.DNSName
             Id: !Ref OriginALB
             CustomOriginConfig:
-              HTTPPort: "80"
-              HTTPSPort: "443"
+              HTTPPort: 80
+              HTTPSPort: 443
               OriginProtocolPolicy: !Ref OriginProtocolPolicy
               OriginKeepaliveTimeout: !Ref OriginKeepaliveTimeout
               OriginReadTimeout: !Ref OriginReadTimeout
@@ -731,45 +736,10 @@ Resources:
             };
       Runtime: nodejs20.x
 
-  # LAMBDA@EDGE VERSION VERSION
   LambdaEdgeVersion:
-    Type: Custom::LambdaVersion
+    Type: AWS::Lambda::Version
     Properties:
-      ServiceToken: !GetAtt LambdaEdgeVersionFunction.Arn
       FunctionName: !Ref LambdaEdgeFunction
-      LambdaCodeVersion: !Ref LambdaFunctionVersion
-
-  # LAMBDA@EDGE VERSION FUNCTION
-  LambdaEdgeVersionFunction:
-    Type: AWS::Lambda::Function
-    Metadata:
-      guard:
-        SuppressedRules:
-          - LAMBDA_INSIDE_VPC
-    Properties:
-      Description: A custom Lambda@Edge Version function
-      FunctionName: !Sub ${AppName}-lambda-edge-version-${Environment}
-      Handler: index.handler
-      Role: !GetAtt LambdaEdgeIAMRole.Arn
-      MemorySize: 128
-      Timeout: 30
-      Code:
-        ZipFile: |
-          var AWS = require('aws-sdk');
-          var response = require('cfn-response');
-          exports.handler = (event, context) => {
-            console.log("Request received:\n", JSON.stringify(event));
-            if (event.RequestType == 'Delete') {
-              return response.send(event, context, response.SUCCESS);
-            }
-            var lambda = new AWS.Lambda();
-            lambda.publishVersion({FunctionName: event.ResourceProperties.FunctionName}).promise().then((data) => {
-              return response.send(event, context, response.SUCCESS, {Version: data.Version}, data.FunctionArn);
-            }).catch((e) => {
-              return response.send(event, context, response.FAILED, e);
-            });
-          };
-      Runtime: nodejs20.x
 
 Outputs:
   AdministratorAccessIAMRole:

--- a/Solutions/CloudFrontCustomOriginLambda@Edge/README.md
+++ b/Solutions/CloudFrontCustomOriginLambda@Edge/README.md
@@ -12,8 +12,15 @@ Using this AWS CloudFormation Template Example enables CI/CD optimized and autom
 ## Instructions
 
 The following steps provide a brief overview of this process:
- * Upload certificate to AWS Amazon Certificate Manager (ACM) in N.Virginia Region
- * Review provided Parameters and set values that match your use case
+ * Upload certificate to AWS Amazon Certificate Manager (ACM) in N.Virginia Region.
+ * Review provided Parameters and set values that match your use case. 
+ * While creating the CloudFormation stack, please make sure to select the following networking parameter values from the dropdown in Parameters section:
+
+    - **VpcId:** Select a VPC ID
+    - **PublicSubnetId1:** Select the first public subnet from the above VPC
+    - **PublicSubnetId2:** Select the second public subnet from the above VPC
+    - **KeyPairName:** Select an EC2 Key Pair
+
  * Expand solution with additional resources as AutoScaling, etc. that match your use case
 
 ## Builders


### PR DESCRIPTION
*Issue #, if available:* [464](https://github.com/aws-cloudformation/aws-cloudformation-templates/issues/464)

*Description of changes:*

- Replaced the ImportValue statements with Parameter values.
- Introduced parameters for networking resources like VpcId and Subnet Ids.
- Removed the custom resource that was used to create Lambda function version. CloudFormation supports the version resource now. We don't need a custom resource. 
- Other minor formatting changes.
- Updated ReadMe with the new parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
