### PR TITLE
Updated SecurityGroupIds property and update ubuntu22 to use SSM parameter for AMI ID

### DIFF
--- a/Solutions/OperatingSystems/RHEL9_cfn-hup.json
+++ b/Solutions/OperatingSystems/RHEL9_cfn-hup.json
@@ -337,9 +337,12 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
+                        "Fn::GetAtt": [
+                            "InstanceSecurityGroup",
+                            "GroupId"
+                        ]
                     }
                 ],
                 "KeyName": {

--- a/Solutions/OperatingSystems/RHEL9_cfn-hup.yaml
+++ b/Solutions/OperatingSystems/RHEL9_cfn-hup.yaml
@@ -264,8 +264,8 @@ Resources:
     Properties:
       InstanceType: !Ref InstanceType
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       KeyName: !Ref KeyName
       ImageId: !FindInMap
         - AWSRegionArch2AMI

--- a/Solutions/OperatingSystems/Ubuntu22.04_cfn-hup.json
+++ b/Solutions/OperatingSystems/Ubuntu22.04_cfn-hup.json
@@ -75,213 +75,11 @@
         },
         "SubnetId": {
             "Type": "AWS::EC2::Subnet::Id"
-        }
-    },
-    "Mappings": {
-        "AWSInstanceType2Arch": {
-            "t1.micro": {
-                "Arch": "HVM64"
-            },
-            "t2.nano": {
-                "Arch": "HVM64"
-            },
-            "t2.micro": {
-                "Arch": "HVM64"
-            },
-            "t2.small": {
-                "Arch": "HVM64"
-            },
-            "t2.medium": {
-                "Arch": "HVM64"
-            },
-            "t2.large": {
-                "Arch": "HVM64"
-            },
-            "m1.small": {
-                "Arch": "HVM64"
-            },
-            "m1.medium": {
-                "Arch": "HVM64"
-            },
-            "m1.large": {
-                "Arch": "HVM64"
-            },
-            "m1.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m2.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m2.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "m2.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "m3.medium": {
-                "Arch": "HVM64"
-            },
-            "m3.large": {
-                "Arch": "HVM64"
-            },
-            "m3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.large": {
-                "Arch": "HVM64"
-            },
-            "m4.xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "m4.10xlarge": {
-                "Arch": "HVM64"
-            },
-            "c1.medium": {
-                "Arch": "HVM64"
-            },
-            "c1.xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.large": {
-                "Arch": "HVM64"
-            },
-            "c3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "c3.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.large": {
-                "Arch": "HVM64"
-            },
-            "c4.xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "c4.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.large": {
-                "Arch": "HVM64"
-            },
-            "r3.xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "r3.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "i2.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.2xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "d2.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "hi1.4xlarge": {
-                "Arch": "HVM64"
-            },
-            "hs1.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "cr1.8xlarge": {
-                "Arch": "HVM64"
-            },
-            "cc2.8xlarge": {
-                "Arch": "HVM64"
-            }
         },
-        "AWSRegionArch2AMI": {
-            "us-east-1": {
-                "HVM64": "ami-08c40ec9ead489470"
-            },
-            "us-west-2": {
-                "HVM64": "ami-017fecd1353bcc96e"
-            },
-            "us-west-1": {
-                "HVM64": "ami-02ea247e531eb3ce6"
-            },
-            "eu-west-1": {
-                "HVM64": "ami-096800910c1b781ba"
-            },
-            "eu-west-2": {
-                "HVM64": "ami-0f540e9f488cfa27d"
-            },
-            "eu-west-3": {
-                "HVM64": "ami-0493936afbe820b28"
-            },
-            "eu-central-1": {
-                "HVM64": "ami-0caef02b518350c8b"
-            },
-            "ap-northeast-1": {
-                "HVM64": "ami-03f4fa076d2981b45"
-            },
-            "ap-northeast-2": {
-                "HVM64": "ami-0e9bfdb247cc8de84"
-            },
-            "ap-northeast-3": {
-                "HVM64": "ami-08c2ee02329b72f26"
-            },
-            "ap-southeast-1": {
-                "HVM64": "ami-07651f0c4c315a529"
-            },
-            "ap-southeast-2": {
-                "HVM64": "ami-09a5c873bc79530d9"
-            },
-            "ap-south-1": {
-                "HVM64": "ami-062df10d14676e201"
-            },
-            "us-east-2": {
-                "HVM64": "ami-097a2df4ac947655f"
-            },
-            "ca-central-1": {
-                "HVM64": "ami-0a7154091c5c6623e"
-            },
-            "sa-east-1": {
-                "HVM64": "ami-04b3c23ec8efcc2d6"
-            }
+        "InstanceAMI": {
+            "Description": "Managed AMI ID for EC2 Instance",
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Default": "/aws/service/canonical/ubuntu/eks-pro/22.04/1.29/stable/current/amd64/hvm/ebs-gp2/ami-id"
         }
     },
     "Resources": {
@@ -340,30 +138,19 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
+                        "Fn::GetAtt": [
+                            "InstanceSecurityGroup",
+                            "GroupId"
+                        ]
                     }
                 ],
                 "KeyName": {
                     "Ref": "KeyName"
                 },
                 "ImageId": {
-                    "Fn::FindInMap": [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap": [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref": "InstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
+                    "Ref": "InstanceAMI"
                 },
                 "UserData": {
                     "Fn::Base64": {

--- a/Solutions/OperatingSystems/Ubuntu22.04_cfn-hup.yaml
+++ b/Solutions/OperatingSystems/Ubuntu22.04_cfn-hup.yaml
@@ -76,144 +76,10 @@ Parameters:
   SubnetId:
     Type: AWS::EC2::Subnet::Id
 
-Mappings:
-  AWSInstanceType2Arch:
-    t1.micro:
-      Arch: HVM64
-    t2.nano:
-      Arch: HVM64
-    t2.micro:
-      Arch: HVM64
-    t2.small:
-      Arch: HVM64
-    t2.medium:
-      Arch: HVM64
-    t2.large:
-      Arch: HVM64
-    m1.small:
-      Arch: HVM64
-    m1.medium:
-      Arch: HVM64
-    m1.large:
-      Arch: HVM64
-    m1.xlarge:
-      Arch: HVM64
-    m2.xlarge:
-      Arch: HVM64
-    m2.2xlarge:
-      Arch: HVM64
-    m2.4xlarge:
-      Arch: HVM64
-    m3.medium:
-      Arch: HVM64
-    m3.large:
-      Arch: HVM64
-    m3.xlarge:
-      Arch: HVM64
-    m3.2xlarge:
-      Arch: HVM64
-    m4.large:
-      Arch: HVM64
-    m4.xlarge:
-      Arch: HVM64
-    m4.2xlarge:
-      Arch: HVM64
-    m4.4xlarge:
-      Arch: HVM64
-    m4.10xlarge:
-      Arch: HVM64
-    c1.medium:
-      Arch: HVM64
-    c1.xlarge:
-      Arch: HVM64
-    c3.large:
-      Arch: HVM64
-    c3.xlarge:
-      Arch: HVM64
-    c3.2xlarge:
-      Arch: HVM64
-    c3.4xlarge:
-      Arch: HVM64
-    c3.8xlarge:
-      Arch: HVM64
-    c4.large:
-      Arch: HVM64
-    c4.xlarge:
-      Arch: HVM64
-    c4.2xlarge:
-      Arch: HVM64
-    c4.4xlarge:
-      Arch: HVM64
-    c4.8xlarge:
-      Arch: HVM64
-    r3.large:
-      Arch: HVM64
-    r3.xlarge:
-      Arch: HVM64
-    r3.2xlarge:
-      Arch: HVM64
-    r3.4xlarge:
-      Arch: HVM64
-    r3.8xlarge:
-      Arch: HVM64
-    i2.xlarge:
-      Arch: HVM64
-    i2.2xlarge:
-      Arch: HVM64
-    i2.4xlarge:
-      Arch: HVM64
-    i2.8xlarge:
-      Arch: HVM64
-    d2.xlarge:
-      Arch: HVM64
-    d2.2xlarge:
-      Arch: HVM64
-    d2.4xlarge:
-      Arch: HVM64
-    d2.8xlarge:
-      Arch: HVM64
-    hi1.4xlarge:
-      Arch: HVM64
-    hs1.8xlarge:
-      Arch: HVM64
-    cr1.8xlarge:
-      Arch: HVM64
-    cc2.8xlarge:
-      Arch: HVM64
-
-  AWSRegionArch2AMI:
-    us-east-1:
-      HVM64: ami-08c40ec9ead489470
-    us-west-2:
-      HVM64: ami-017fecd1353bcc96e
-    us-west-1:
-      HVM64: ami-02ea247e531eb3ce6
-    eu-west-1:
-      HVM64: ami-096800910c1b781ba
-    eu-west-2:
-      HVM64: ami-0f540e9f488cfa27d
-    eu-west-3:
-      HVM64: ami-0493936afbe820b28
-    eu-central-1:
-      HVM64: ami-0caef02b518350c8b
-    ap-northeast-1:
-      HVM64: ami-03f4fa076d2981b45
-    ap-northeast-2:
-      HVM64: ami-0e9bfdb247cc8de84
-    ap-northeast-3:
-      HVM64: ami-08c2ee02329b72f26
-    ap-southeast-1:
-      HVM64: ami-07651f0c4c315a529
-    ap-southeast-2:
-      HVM64: ami-09a5c873bc79530d9
-    ap-south-1:
-      HVM64: ami-062df10d14676e201
-    us-east-2:
-      HVM64: ami-097a2df4ac947655f
-    ca-central-1:
-      HVM64: ami-0a7154091c5c6623e
-    sa-east-1:
-      HVM64: ami-04b3c23ec8efcc2d6
+  InstanceAMI:
+    Description: Managed AMI ID for EC2 Instance
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/eks-pro/22.04/1.29/stable/current/amd64/hvm/ebs-gp2/ami-id
 
 Resources:
   EC2Instance:
@@ -265,16 +131,10 @@ Resources:
     Properties:
       InstanceType: !Ref InstanceType
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       KeyName: !Ref KeyName
-      ImageId: !FindInMap
-        - AWSRegionArch2AMI
-        - !Ref AWS::Region
-        - !FindInMap
-          - AWSInstanceType2Arch
-          - !Ref InstanceType
-          - Arch
+      ImageId: !Ref InstanceAMI
       UserData: !Base64
         Fn::Sub: |
           #!/bin/bash -xe

--- a/Solutions/OperatingSystems/ubuntu20.04_cfn-hup.json
+++ b/Solutions/OperatingSystems/ubuntu20.04_cfn-hup.json
@@ -304,22 +304,7 @@
                         "files": {
                             "/etc/cfn/cfn-hup.conf": {
                                 "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "[main]\n",
-                                            "stack=",
-                                            {
-                                                "Ref": "AWS::StackId"
-                                            },
-                                            "",
-                                            "region=",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            ""
-                                        ]
-                                    ]
+                                    "Fn::Sub": "[main]\nstack=${AWS::StackId}\nregion=${AWS::Region}\n"
                                 },
                                 "mode": "000400",
                                 "owner": "root",
@@ -327,48 +312,14 @@
                             },
                             "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
                                 "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "[cfn-auto-reloader-hook]\n",
-                                            "triggers=post.update\n",
-                                            "path=Resources.WebServerInstance.Metadata.AWS::CloudFormation::Init\n",
-                                            "action=/usr/local/bin/cfn-init -v ",
-                                            "         --stack ",
-                                            {
-                                                "Ref": "AWS::StackName"
-                                            },
-                                            "         --resource WebServerInstance ",
-                                            "         --configsets InstallAndRun ",
-                                            "         --region ",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            "",
-                                            "runas=root\n"
-                                        ]
-                                    ]
+                                    "Fn::Sub": "[cfn-auto-reloader-hook]\ntriggers=post.update\npath=Resources.WebServerInstance.Metadata.AWS::CloudFormation::Init\naction=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource WebServerInstance --configsets InstallAndRun --region ${AWS::Region}\nrunas=root              \n"
                                 },
                                 "mode": "000400",
                                 "owner": "root",
                                 "group": "root"
                             },
                             "/lib/systemd/system/cfn-hup.service": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "[Unit]\n",
-                                            "Description=cfn-hup daemon\n\n",
-                                            "[Service]\n",
-                                            "Type=simple ",
-                                            "ExecStart=/usr/local/bin/cfn-hup ",
-                                            "Restart=always\n\n",
-                                            "[Install]\n",
-                                            "WantedBy=multi-user.target"
-                                        ]
-                                    ]
-                                }
+                                "content": "[Unit]\nDescription=cfn-hup daemon\n[Service]\nType=simple\nExecStart=/usr/local/bin/cfn-hup\nRestart=always\n[Install]\nWantedBy=multi-user.target\n"
                             }
                         },
                         "commands": {
@@ -389,9 +340,12 @@
                 "SubnetId": {
                     "Ref": "SubnetId"
                 },
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
-                        "Ref": "InstanceSecurityGroup"
+                        "Fn::GetAtt": [
+                            "InstanceSecurityGroup",
+                            "GroupId"
+                        ]
                     }
                 ],
                 "KeyName": {

--- a/Solutions/OperatingSystems/ubuntu20.04_cfn-hup.yaml
+++ b/Solutions/OperatingSystems/ubuntu20.04_cfn-hup.yaml
@@ -230,59 +230,33 @@ Resources:
         install_and_enable_cfn_hup:
           files:
             /etc/cfn/cfn-hup.conf:
-              content: !Join
-                - ""
-                - - |
-                    [main]
-                  - stack=
-                  - !Ref AWS::StackId
-                  - ""
-                  - region=
-                  - !Ref AWS::Region
-                  - ""
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
               mode: "000400"
               owner: root
               group: root
             /etc/cfn/hooks.d/cfn-auto-reloader.conf:
-              content: !Join
-                - ""
-                - - |
-                    [cfn-auto-reloader-hook]
-                  - |
-                    triggers=post.update
-                  - |
-                    path=Resources.WebServerInstance.Metadata.AWS::CloudFormation::Init
-                  - 'action=/usr/local/bin/cfn-init -v '
-                  - '         --stack '
-                  - !Ref AWS::StackName
-                  - '         --resource WebServerInstance '
-                  - '         --configsets InstallAndRun '
-                  - '         --region '
-                  - !Ref AWS::Region
-                  - ""
-                  - |
-                    runas=root
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.WebServerInstance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource WebServerInstance --configsets InstallAndRun --region ${AWS::Region}
+                runas=root              
               mode: "000400"
               owner: root
               group: root
             /lib/systemd/system/cfn-hup.service:
-              content: !Join
-                - ""
-                - - |
-                    [Unit]
-                  - |+
-                    Description=cfn-hup daemon
-
-                  - |
-                    [Service]
-                  - 'Type=simple '
-                  - 'ExecStart=/usr/local/bin/cfn-hup '
-                  - |+
-                    Restart=always
-
-                  - |
-                    [Install]
-                  - WantedBy=multi-user.target
+              content: |
+                [Unit]
+                Description=cfn-hup daemon
+                [Service]
+                Type=simple
+                ExecStart=/usr/local/bin/cfn-hup
+                Restart=always
+                [Install]
+                WantedBy=multi-user.target
           commands:
             01enable_cfn_hup:
               command: systemctl enable cfn-hup.service
@@ -291,8 +265,8 @@ Resources:
     Properties:
       InstanceType: !Ref InstanceType
       SubnetId: !Ref SubnetId
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
+      SecurityGroupIds:
+        - !GetAtt InstanceSecurityGroup.GroupId
       KeyName: !Ref KeyName
       ImageId: !FindInMap
         - AWSRegionArch2AMI


### PR DESCRIPTION
*Issue #, if available:* [Issue 470](https://github.com/aws-cloudformation/aws-cloudformation-templates/issues/470)

*Description of changes:*

1. Updated SecurityGroup property to stack failures for all three templates.
2. Updated Ubuntu22.04 template to use SSM parameter instead of hardcoded values for AMI. RHEL and Ubuntu20 doesn't support SSM parameter, left them as is.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
