### PR TITLE
Update AutoScalingScheduledAction.yaml --- fix launchConfig deprecated problem and fix `insert new line` needed in !Join problem

### DIFF
--- a/AutoScaling/AutoScalingScheduledAction.yaml
+++ b/AutoScaling/AutoScalingScheduledAction.yaml
@@ -284,7 +284,9 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       AvailabilityZones: !GetAZs
-      LaunchConfigurationName: !Ref LaunchConfig
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
       MinSize: 2
       MaxSize: 5
       LoadBalancerNames:
@@ -306,8 +308,8 @@ Resources:
       MinSize: "1"
       Recurrence: 0 19 * * *
 
-  LaunchConfig:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
     Metadata:
       Comment: Install a simple application
       AWS::CloudFormation::Init:
@@ -330,32 +332,20 @@ Resources:
               owner: root
               group: root
             /etc/cfn/cfn-hup.conf:
-              content: !Join
-                - ""
-                - - '[main] '
-                  - stack=
-                  - !Ref AWS::StackId
-                  - ' '
-                  - region=
-                  - !Ref AWS::Region
-                  - ' '
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
               mode: "000400"
               owner: root
               group: root
             /etc/cfn/hooks.d/cfn-auto-reloader.conf:
-              content: !Join
-                - ""
-                - - '[cfn-auto-reloader-hook] '
-                  - 'triggers=post.update '
-                  - 'path=Resources.LaunchConfig.Metadata.AWS::CloudFormation::Init '
-                  - 'action=/opt/aws/bin/cfn-init -v '
-                  - '         --stack '
-                  - !Ref AWS::StackName
-                  - '         --resource LaunchConfig '
-                  - '         --region '
-                  - !Ref AWS::Region
-                  - ' '
-                  - 'runas=root '
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.LaunchTemplate.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LaunchTemplate --region ${AWS::Region}
+                runas=root
           services:
             sysvinit:
               httpd:
@@ -368,36 +358,24 @@ Resources:
                   - /etc/cfn/cfn-hup.conf
                   - /etc/cfn/hooks.d/cfn-auto-reloader.conf
     Properties:
-      KeyName: !Ref KeyName
-      ImageId: !FindInMap
-        - AWSRegionArch2AMI
-        - !Ref AWS::Region
-        - !FindInMap
-          - AWSInstanceType2Arch
-          - !Ref InstanceType
-          - Arch
-      SecurityGroups:
-        - !Ref InstanceSecurityGroup
-      InstanceType: !Ref InstanceType
-      UserData: !Base64
-        Fn::Join:
-          - ""
-          - - '#!/bin/bash -xe '
-            - 'yum update -y aws-cfn-bootstrap '
-            - '/opt/aws/bin/cfn-init -v '
-            - '         --stack '
-            - !Ref AWS::StackName
-            - '         --resource LaunchConfig '
-            - '         --region '
-            - !Ref AWS::Region
-            - ' '
-            - '/opt/aws/bin/cfn-signal -e $? '
-            - '         --stack '
-            - !Ref AWS::StackName
-            - '         --resource WebServerGroup '
-            - '         --region '
-            - !Ref AWS::Region
-            - ' '
+      LaunchTemplateData:
+        KeyName: !Ref KeyName
+        ImageId: !FindInMap
+          - AWSRegionArch2AMI
+          - !Ref AWS::Region
+          - !FindInMap
+            - AWSInstanceType2Arch
+            - !Ref InstanceType
+            - Arch
+        SecurityGroups:
+          - !Ref InstanceSecurityGroup
+        InstanceType: !Ref InstanceType
+        UserData: !Base64
+          Fn::Sub: |
+            #!/bin/bash -xe
+            yum install -y aws-cfn-bootstrap
+            /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LaunchTemplate  --region ${AWS::Region}
+            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WebServerGroup --region ${AWS::Region}
 
   ElasticLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer


### PR DESCRIPTION
fix launchConfig and !Join no `new line` problem


*Issue #, if available:*
1. launchConfig deprecated problem
2. `insert new line` needed in !Join function. When using the `!Join` method, you need to explicitly include a newline character to indicate line breaks.

*Description of changes:*
this PR resolve two problems
1. launchConfig has been deprecated, this PR replaces with LaunchTemplate
2. `inserting new line` is needed in !Join function, this PR replaces  with !Sub function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
