### PR TITLE
Update private-vpc.yaml -- fix "launch configurations deprecated" problem

### DIFF
--- a/ECS/EC2LaunchType/clusters/private-vpc.yaml
+++ b/ECS/EC2LaunchType/clusters/private-vpc.yaml
@@ -340,25 +340,29 @@ Resources:
       VPCZoneIdentifier:
         - !Ref PrivateSubnetOne
         - !Ref PrivateSubnetTwo
-      LaunchConfigurationName: !Ref ContainerInstances
+      LaunchTemplate:
+        LaunchTemplateId: !Ref ContainerInstances
+        Version: !GetAtt ContainerInstances.LatestVersionNumber
       MinSize: 1
       MaxSize: !Ref MaxSize
       DesiredCapacity: !Ref DesiredCapacity
 
   ContainerInstances:
-    Type: AWS::AutoScaling::LaunchConfiguration
+    Type: AWS::EC2::LaunchTemplate
     Properties:
-      ImageId: !Ref ECSAMI
-      SecurityGroups:
-        - !Ref EcsHostSecurityGroup
-      InstanceType: !Ref InstanceType
-      IamInstanceProfile: !Ref EC2InstanceProfile
-      UserData: !Base64
-        Fn::Sub: |
-          #!/bin/bash -xe
-          echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
-          yum install -y aws-cfn-bootstrap
-          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}
+      LaunchTemplateData:
+        ImageId: !Ref ECSAMI
+        SecurityGroupIds:
+          - !Ref EcsHostSecurityGroup
+        InstanceType: !Ref InstanceType
+        IamInstanceProfile: 
+          Arn: !GetAtt EC2InstanceProfile.Arn
+        UserData: !Base64
+          Fn::Sub: |
+            #!/bin/bash -xe
+            echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
+            yum install -y aws-cfn-bootstrap
+            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}
 
   AutoscalingRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION



*Issue #, if available:*

EC2 Auto Scaling no longer supports new EC2 features or new EC2 instance types released after December 31, 2022 through launch configurations. AWS recommended that you use launch templates to create new Auto Scaling groups and migrate any existing launch configurations to launch templates.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
